### PR TITLE
Update Evan Amies-Galonski email to personal address

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: Kootenay Lake Nutrient Restoration Program Data Loading
 Version: 0.2.1
 Authors@R: 
     c(
-    person("Evan", "Amies-Galonski", role = c("aut", "cre"), email = "evan@poissonconsulting.ca", comment = c(ORCID = "0000-0003-1096-2089")),
+    person("Evan", "Amies-Galonski", role = c("aut", "cre"), email = "evanamiesgalonski@gmail.com", comment = c(ORCID = "0000-0003-1096-2089")),
     person("Joe", "Thorley", role = "aut", email = "joe@poissonconsulting.ca", comment = c(ORCID = "0000-0002-7683-4592")),
     person("Province of British Columbia", role = c("cph", "fnd"))
   )


### PR DESCRIPTION
Replaces `evan@poissonconsulting.ca` (no longer an active address) with Evan's personal email `evanamiesgalonski@gmail.com` in DESCRIPTION.