### PR TITLE
chore: Format with air

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,5 @@
 ^LICENSE\.md$
 ^_pkgdown\.yml$
 ^README\.Rmd$
+^[.]?air[.]toml$
+^\.vscode$

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[r]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "Posit.air-vscode"
+  },
+  "[quarto]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "quarto.quarto"
+  }
+}

--- a/R/check.R
+++ b/R/check.R
@@ -3,7 +3,11 @@ check_chr_date <- function(x) {
   chk::chk_character(x, x_name = x_name)
   chk::chk_scalar(x, x_name = x_name)
 
-  date <- tryCatch(dttr2::dtt_date(x), error = function(e) e, warning = function(w) w)
+  date <- tryCatch(
+    dttr2::dtt_date(x),
+    error = function(e) e,
+    warning = function(w) w
+  )
 
   if (inherits(date, "error") || inherits(date, "warning")) {
     err("Invalid date for ", x_name, ". Please use format: yyyy-mm-dd.")
@@ -18,11 +22,18 @@ check_chr_datetime <- function(x) {
   chk::chk_character(x, x_name = x_name)
   chk::chk_scalar(x, x_name = x_name)
 
-  datetime <- tryCatch(dttr2::dtt_date_time(x), error = function(e) e, warning = function(w) w)
-
+  datetime <- tryCatch(
+    dttr2::dtt_date_time(x),
+    error = function(e) e,
+    warning = function(w) w
+  )
 
   if (inherits(datetime, "error") || inherits(datetime, "warning")) {
-    err("Invalid date-time for ", x_name, ". Please use format: yyyy-mm-dd hh:mm:ss with 24 hour time.")
+    err(
+      "Invalid date-time for ",
+      x_name,
+      ". Please use format: yyyy-mm-dd hh:mm:ss with 24 hour time."
+    )
   } else if (datetime > dttr2::dtt_date_time(Sys.Date())) {
     err(x_name, " is beyond current date.")
   }
@@ -44,15 +55,23 @@ check_ext <- function(path, ext = "sqlite") {
 
 check_file_exists <- function(path) {
   check_path(path)
-  if (!file_exists(path)) err("path '", path, "' must exist")
-  if (!is_file(path)) err("path '", path, "' must be a file")
+  if (!file_exists(path)) {
+    err("path '", path, "' must exist")
+  }
+  if (!is_file(path)) {
+    err("path '", path, "' must be a file")
+  }
   path
 }
 
 check_dir_exists <- function(path) {
   check_path(path)
-  if (!file_exists(path)) err("path '", path, "' must exist")
-  if (!is_dir(path)) err("path '", path, "' must be a directory")
+  if (!file_exists(path)) {
+    err("path '", path, "' must exist")
+  }
+  if (!is_dir(path)) {
+    err("path '", path, "' must be a directory")
+  }
   path
 }
 
@@ -80,7 +99,8 @@ check_ctd_data <- function(data, exclusive = FALSE, order = FALSE) {
       Retain = TRUE,
       File = as.character()
     ),
-    exclusive = exclusive, order = order
+    exclusive = exclusive,
+    order = order
   )
 }
 
@@ -181,7 +201,10 @@ check_ems_metals_data <- function(data, exclusive = FALSE, order = FALSE) {
       `Nickel Total` = units::as_units(c(NA, 1), "mg/l"),
       `Limit Nickel Total` = units::as_units(c(NA, 1), "mg/l"),
       `Phosphorus Total Dissolved metals` = units::as_units(c(NA, 1), "mg/l"),
-      `Limit Phosphorus Total Dissolved metals` = units::as_units(c(NA, 1), "mg/l"),
+      `Limit Phosphorus Total Dissolved metals` = units::as_units(
+        c(NA, 1),
+        "mg/l"
+      ),
       `Phosphorus Total metals` = units::as_units(c(NA, 1), "mg/l"),
       `Limit Phosphorus Total metals` = units::as_units(c(NA, 1), "mg/l"),
       `Potassium Dissolved` = units::as_units(c(NA, 1), "mg/l"),
@@ -238,10 +261,17 @@ check_ems_metals_data <- function(data, exclusive = FALSE, order = FALSE) {
       `Limit Zinc Total` = units::as_units(c(NA, 1), "mg/l")
     ),
     key = c(
-      "SiteID", "COLLECTION_START", "COLLECTION_END", "REQUISITION_ID",
-      "ANALYZING_AGENCY", "UPPER_DEPTH", "LOWER_DEPTH", "ReplicateID"
+      "SiteID",
+      "COLLECTION_START",
+      "COLLECTION_END",
+      "REQUISITION_ID",
+      "ANALYZING_AGENCY",
+      "UPPER_DEPTH",
+      "LOWER_DEPTH",
+      "ReplicateID"
     ),
-    exclusive = exclusive, order = order
+    exclusive = exclusive,
+    order = order
   )
 }
 
@@ -270,10 +300,19 @@ check_ems_standard_data <- function(data, exclusive = FALSE, order = FALSE) {
       `Limit Chlorophyll A` = units::as_units(c(NA, 1), "mg/l"),
       `Nitrate (NO3) Dissolved` = units::as_units(c(NA, 1), "mg/l"),
       `Limit Nitrate (NO3) Dissolved` = units::as_units(c(NA, 1), "mg/l"),
-      `Nitrate(NO3) + Nitrite(NO2) Dissolved` = units::as_units(c(NA, 1), "mg/l"),
-      `Limit Nitrate(NO3) + Nitrite(NO2) Dissolved` = units::as_units(c(NA, 1), "mg/l"),
+      `Nitrate(NO3) + Nitrite(NO2) Dissolved` = units::as_units(
+        c(NA, 1),
+        "mg/l"
+      ),
+      `Limit Nitrate(NO3) + Nitrite(NO2) Dissolved` = units::as_units(
+        c(NA, 1),
+        "mg/l"
+      ),
       `Nitrogen - Nitrite Dissolved (NO2)` = units::as_units(c(NA, 1), "mg/l"),
-      `Limit Nitrogen - Nitrite Dissolved (NO2)` = units::as_units(c(NA, 1), "mg/l"),
+      `Limit Nitrogen - Nitrite Dissolved (NO2)` = units::as_units(
+        c(NA, 1),
+        "mg/l"
+      ),
       `Nitrogen Ammonia Total` = units::as_units(c(NA, 1), "mg/l"),
       `Limit Nitrogen Ammonia Total` = units::as_units(c(NA, 1), "mg/l"),
       `Nitrogen Total` = units::as_units(c(NA, 1), "mg/l"),
@@ -292,10 +331,17 @@ check_ems_standard_data <- function(data, exclusive = FALSE, order = FALSE) {
       `Limit Turbidity` = units::as_units(c(NA, 1), "NTU")
     ),
     key = c(
-      "SiteID", "COLLECTION_START", "COLLECTION_END", "REQUISITION_ID",
-      "ANALYZING_AGENCY", "UPPER_DEPTH", "LOWER_DEPTH", "ReplicateID"
+      "SiteID",
+      "COLLECTION_START",
+      "COLLECTION_END",
+      "REQUISITION_ID",
+      "ANALYZING_AGENCY",
+      "UPPER_DEPTH",
+      "LOWER_DEPTH",
+      "ReplicateID"
     ),
-    exclusive = exclusive, order = order
+    exclusive = exclusive,
+    order = order
   )
 }
 
@@ -329,7 +375,8 @@ check_ems_raw_data <- function(data, exclusive = FALSE, order = FALSE) {
       "UPPER_DEPTH",
       "LOWER_DEPTH"
     ),
-    exclusive = exclusive, order = order
+    exclusive = exclusive,
+    order = order
   )
   data
 }
@@ -343,7 +390,8 @@ check_site_date_lookup <- function(data, exclusive = FALSE, order = FALSE) {
       SiteID = "character"
     ),
     key = c("File"),
-    exclusive = exclusive, order = order
+    exclusive = exclusive,
+    order = order
   )
 }
 
@@ -353,13 +401,16 @@ check_mysid_raw_data <- function(data, exclusive = TRUE, order = TRUE) {
     check_names(
       data,
       names = names(nrp::mysid_input_cols),
-      exclusive = exclusive, order = order
+      exclusive = exclusive,
+      order = order
     ),
     silent = TRUE
   )
 
   if (inherits(data, "try-error")) {
-    err("Columns in data do not match template for mysid raw data. see `nrp::mysid_input_cols` for correct column names and order.")
+    err(
+      "Columns in data do not match template for mysid raw data. see `nrp::mysid_input_cols` for correct column names and order."
+    )
   }
   invisible(data)
 }
@@ -370,13 +421,16 @@ check_zoo_raw_data <- function(data, exclusive = TRUE, order = TRUE) {
     check_names(
       data,
       names = names(nrp::zoo_input_cols),
-      exclusive = exclusive, order = order
+      exclusive = exclusive,
+      order = order
     ),
     silent = TRUE
   )
 
   if (inherits(data, "try-error")) {
-    err("Columns in data do not match template for zooplankton raw data. see `nrp::zoo_input_cols` for correct column names and order.")
+    err(
+      "Columns in data do not match template for zooplankton raw data. see `nrp::zoo_input_cols` for correct column names and order."
+    )
   }
   invisible(data)
 }
@@ -387,13 +441,16 @@ check_phyto_raw_data <- function(data, exclusive = TRUE, order = TRUE) {
     check_names(
       data,
       names = names(nrp::phyto_input_cols),
-      exclusive = exclusive, order = order
+      exclusive = exclusive,
+      order = order
     ),
     silent = TRUE
   )
 
   if (inherits(data, "try-error")) {
-    err("Columns in data do not match template for phytoplankton raw data. see `nrp::phyto_input_cols` for correct column names and order.")
+    err(
+      "Columns in data do not match template for phytoplankton raw data. see `nrp::phyto_input_cols` for correct column names and order."
+    )
   }
   invisible(data)
 }

--- a/R/connect.R
+++ b/R/connect.R
@@ -3,7 +3,12 @@ connect_if_valid_path <- function(path) {
   suppressWarnings(withCallingHandlers(
     conn <- readwritesqlite::rws_open_connection(dbname = path, exists = TRUE),
     warning = function(w) {
-      if (str_detect(w$message, "Couldn't set synchronous mode: file is not a database")) {
+      if (
+        str_detect(
+          w$message,
+          "Couldn't set synchronous mode: file is not a database"
+        )
+      ) {
         err("File provided is not an SQLite database")
       }
     }

--- a/R/create-db.R
+++ b/R/create-db.R
@@ -461,43 +461,103 @@ nrp_create_db <- function(path, ask = getOption("nrp.ask", TRUE)) {
   readwritesqlite::rws_write(lakes, exists = TRUE, conn = conn, x_name = "Lake")
 
   basinArm <- nrp::basinArm
-  readwritesqlite::rws_write(basinArm, exists = TRUE, conn = conn, x_name = "BasinArm")
+  readwritesqlite::rws_write(
+    basinArm,
+    exists = TRUE,
+    conn = conn,
+    x_name = "BasinArm"
+  )
 
   ctdSites <- nrp::ctdSites
-  readwritesqlite::rws_write(ctdSites, exists = TRUE, conn = conn, x_name = "Sites")
+  readwritesqlite::rws_write(
+    ctdSites,
+    exists = TRUE,
+    conn = conn,
+    x_name = "Sites"
+  )
 
   visitCTD <- initialize_ctd_visit()
-  readwritesqlite::rws_write(visitCTD, exists = TRUE, conn = conn, x_name = "visitCTD")
+  readwritesqlite::rws_write(
+    visitCTD,
+    exists = TRUE,
+    conn = conn,
+    x_name = "visitCTD"
+  )
 
   ctd <- initialize_ctd()
   readwritesqlite::rws_write(ctd, exists = TRUE, conn = conn, x_name = "CTD")
 
   ems_metals <- nrp::ems_metals_init
-  readwritesqlite::rws_write(ems_metals, exists = TRUE, conn = conn, x_name = "metalsEMS")
+  readwritesqlite::rws_write(
+    ems_metals,
+    exists = TRUE,
+    conn = conn,
+    x_name = "metalsEMS"
+  )
 
   ems_standard <- nrp::ems_standard_init
-  readwritesqlite::rws_write(ems_standard, exists = TRUE, conn = conn, x_name = "standardEMS")
+  readwritesqlite::rws_write(
+    ems_standard,
+    exists = TRUE,
+    conn = conn,
+    x_name = "standardEMS"
+  )
 
   mysid_sample_init <- initialize_mysid_sample()
-  readwritesqlite::rws_write(mysid_sample_init, exists = TRUE, conn = conn, x_name = "MysidSample")
+  readwritesqlite::rws_write(
+    mysid_sample_init,
+    exists = TRUE,
+    conn = conn,
+    x_name = "MysidSample"
+  )
 
   mysid_init <- initialize_mysid()
-  readwritesqlite::rws_write(mysid_init, exists = TRUE, conn = conn, x_name = "Mysid")
+  readwritesqlite::rws_write(
+    mysid_init,
+    exists = TRUE,
+    conn = conn,
+    x_name = "Mysid"
+  )
 
   zoo_sample_init <- initialize_zoo_sample()
-  readwritesqlite::rws_write(zoo_sample_init, exists = TRUE, conn = conn, x_name = "ZooplanktonSample")
+  readwritesqlite::rws_write(
+    zoo_sample_init,
+    exists = TRUE,
+    conn = conn,
+    x_name = "ZooplanktonSample"
+  )
 
   zoo_init <- initialize_zoo()
-  readwritesqlite::rws_write(zoo_init, exists = TRUE, conn = conn, x_name = "Zooplankton")
+  readwritesqlite::rws_write(
+    zoo_init,
+    exists = TRUE,
+    conn = conn,
+    x_name = "Zooplankton"
+  )
 
   phyto_species <- nrp::phyto_species
-  readwritesqlite::rws_write(phyto_species, exists = TRUE, conn = conn, x_name = "PhytoplanktonSpecies")
+  readwritesqlite::rws_write(
+    phyto_species,
+    exists = TRUE,
+    conn = conn,
+    x_name = "PhytoplanktonSpecies"
+  )
 
   phyto_sample_init <- initialize_phyto_sample()
-  readwritesqlite::rws_write(phyto_sample_init, exists = TRUE, conn = conn, x_name = "PhytoplanktonSample")
+  readwritesqlite::rws_write(
+    phyto_sample_init,
+    exists = TRUE,
+    conn = conn,
+    x_name = "PhytoplanktonSample"
+  )
 
   phyto_init <- initialize_phyto()
-  readwritesqlite::rws_write(phyto_init, exists = TRUE, conn = conn, x_name = "Phytoplankton")
+  readwritesqlite::rws_write(
+    phyto_init,
+    exists = TRUE,
+    conn = conn,
+    x_name = "Phytoplankton"
+  )
 
   conn
 }

--- a/R/ctd.R
+++ b/R/ctd.R
@@ -6,8 +6,11 @@
 #' this defaults to a dataset provided with the package that is used for reading historical data
 #' @return A tibble
 #' @export
-nrp_read_ctd_file <- function(path, db_path = getOption("nrp.db_path", file.choose()),
-                              lookup = nrp::site_date_lookup) {
+nrp_read_ctd_file <- function(
+  path,
+  db_path = getOption("nrp.db_path", file.choose()),
+  lookup = nrp::site_date_lookup
+) {
   check_file_exists(path)
   check_site_date_lookup(data = lookup)
 
@@ -47,13 +50,21 @@ nrp_read_ctd_file <- function(path, db_path = getOption("nrp.db_path", file.choo
     data$DateTime <- ctd@metadata$startTime
     data$DateTime %<>% dttr2::dtt_set_tz("Etc/GMT+8")
 
-    data %<>% rename("SiteID" = "Siteid") %>%
+    data %<>%
+      rename("SiteID" = "Siteid") %>%
       select("SiteID", "DateTime", everything())
   } else {
     col_names <- c(
-      "Depth", "Temperature", "Oxygen", "Oxygen2",
-      "Specificconductance", "Conductivity", "Salinity", "Backscatter",
-      "Fluorescence", "Flag"
+      "Depth",
+      "Temperature",
+      "Oxygen",
+      "Oxygen2",
+      "Specificconductance",
+      "Conductivity",
+      "Salinity",
+      "Backscatter",
+      "Fluorescence",
+      "Flag"
     )
 
     data <- utils::read.table(file = path, col.names = col_names, skip = 100)
@@ -83,17 +94,47 @@ nrp_read_ctd_file <- function(path, db_path = getOption("nrp.db_path", file.choo
     group_by(Cast) %>%
     mutate(Retain = if_else(duplicated(Depth, fromLast = TRUE), FALSE, TRUE))
 
-  data %<>% select(
-    "FileID", "SiteID", "DateTime", "Depth", "Cast", "Temperature", "Oxygen", "Oxygen2",
-    "Conductivity" = "Specificconductance", "Conductivity2" = "Conductivity",
-    "Salinity", "Backscatter", "Fluorescence",
-    "Frequency", "Flag", "Pressure", "Retain", "File"
-  )
+  data %<>%
+    select(
+      "FileID",
+      "SiteID",
+      "DateTime",
+      "Depth",
+      "Cast",
+      "Temperature",
+      "Oxygen",
+      "Oxygen2",
+      "Conductivity" = "Specificconductance",
+      "Conductivity2" = "Conductivity",
+      "Salinity",
+      "Backscatter",
+      "Fluorescence",
+      "Frequency",
+      "Flag",
+      "Pressure",
+      "Retain",
+      "File"
+    )
 
   default_units <- c(
-    NA, NA, NA, "m", NA, "degC", "mg/l", "percent", "uS/cm",
-    "mu * S/cm", "PSU",
-    "NTU", "ug/L", "Hz", NA, "dbar", NA, NA
+    NA,
+    NA,
+    NA,
+    "m",
+    NA,
+    "degC",
+    "mg/l",
+    "percent",
+    "uS/cm",
+    "mu * S/cm",
+    "PSU",
+    "NTU",
+    "ug/L",
+    "Hz",
+    NA,
+    "dbar",
+    NA,
+    NA
   )
   data %<>% map2_dfc(default_units, fill_units)
   units(data$Temperature) <- NULL
@@ -104,10 +145,15 @@ nrp_read_ctd_file <- function(path, db_path = getOption("nrp.db_path", file.choo
   data$Time[data$Time == 00:00:00] <- NA_real_
   data$Date <- dttr2::dtt_date(data$DateTime)
 
-  data %<>% select(
-    "FileID", "SiteID", "Date", "Time",
-    everything(), -"DateTime"
-  )
+  data %<>%
+    select(
+      "FileID",
+      "SiteID",
+      "Date",
+      "Time",
+      everything(),
+      -"DateTime"
+    )
   data
 }
 
@@ -123,24 +169,35 @@ nrp_read_ctd_file <- function(path, db_path = getOption("nrp.db_path", file.choo
 #' @return A tibble.
 #' @export
 #'
-nrp_read_ctd <- function(path = ".", db_path = getOption("nrp.db_path", file.choose()),
-                         recursive = FALSE, regexp = "[.]cnv$",
-                         fail = TRUE, lookup = nrp::site_date_lookup) {
+nrp_read_ctd <- function(
+  path = ".",
+  db_path = getOption("nrp.db_path", file.choose()),
+  recursive = FALSE,
+  regexp = "[.]cnv$",
+  fail = TRUE,
+  lookup = nrp::site_date_lookup
+) {
   check_dir_exists(path)
   chk::chk_chr(regexp)
   chk::chk_flag(recursive)
   chk::chk_flag(fail)
 
   check_dir_exists(path)
-  paths <- dir_ls(path,
-    type = "file", recurse = recursive, regexp = regexp,
+  paths <- dir_ls(
+    path,
+    type = "file",
+    recurse = recursive,
+    regexp = regexp,
     fail = fail
   )
   if (!length(paths)) {
     return(named_list())
   }
 
-  datas <- suppressWarnings(do.call("rbind", map(paths, ~ nrp_read_ctd_file(., db_path = db_path))))
+  datas <- suppressWarnings(do.call(
+    "rbind",
+    map(paths, ~ nrp_read_ctd_file(., db_path = db_path))
+  ))
   rownames(datas) <- NULL
 
   datas
@@ -151,7 +208,9 @@ nrp_read_ctd <- function(path = ".", db_path = getOption("nrp.db_path", file.cho
 #' @return site table
 #' @export
 #'
-nrp_download_sites <- function(db_path = getOption("nrp.db_path", file.choose())) {
+nrp_download_sites <- function(
+  db_path = getOption("nrp.db_path", file.choose())
+) {
   conn <- db_path
 
   if (!inherits(conn, "SQLiteConnection")) {
@@ -166,7 +225,9 @@ nrp_download_sites <- function(db_path = getOption("nrp.db_path", file.choose())
 #' @return CTD visit table
 #' @export
 #'
-nrp_download_ctd_visit <- function(db_path = getOption("nrp.db_path", file.choose())) {
+nrp_download_ctd_visit <- function(
+  db_path = getOption("nrp.db_path", file.choose())
+) {
   conn <- db_path
 
   if (!inherits(conn, "SQLiteConnection")) {
@@ -181,7 +242,9 @@ nrp_download_ctd_visit <- function(db_path = getOption("nrp.db_path", file.choos
 #' @return CTD BasinArm table
 #' @export
 #'
-nrp_download_ctd_basin_arm <- function(db_path = getOption("nrp.db_path", file.choose())) {
+nrp_download_ctd_basin_arm <- function(
+  db_path = getOption("nrp.db_path", file.choose())
+) {
   conn <- db_path
 
   if (!inherits(conn, "SQLiteConnection")) {
@@ -197,7 +260,9 @@ nrp_download_ctd_basin_arm <- function(db_path = getOption("nrp.db_path", file.c
 #' @return CTD Lakes table
 #' @export
 #'
-nrp_download_lakes <- function(db_path = getOption("nrp.db_path", file.choose())) {
+nrp_download_lakes <- function(
+  db_path = getOption("nrp.db_path", file.choose())
+) {
   conn <- db_path
 
   if (!inherits(conn, "SQLiteConnection")) {
@@ -217,7 +282,10 @@ nrp_download_lakes <- function(db_path = getOption("nrp.db_path", file.choose())
 #' @param db_path The SQLite connection object or path to the SQLite database
 #' @export
 #'
-nrp_add_sites <- function(data, db_path = getOption("nrp.db_path", file.choose())) {
+nrp_add_sites <- function(
+  data,
+  db_path = getOption("nrp.db_path", file.choose())
+) {
   conn <- db_path
   if (!inherits(conn, "SQLiteConnection")) {
     conn <- connect_if_valid_path(path = conn)
@@ -228,8 +296,12 @@ nrp_add_sites <- function(data, db_path = getOption("nrp.db_path", file.choose()
   data$MaxDepth <- units::set_units(data$MaxDepth, "m")
 
   readwritesqlite::rws_write(
-    x = data, commit = TRUE, strict = TRUE, silent = TRUE,
-    x_name = "Sites", conn = conn
+    x = data,
+    commit = TRUE,
+    strict = TRUE,
+    silent = TRUE,
+    x_name = "Sites",
+    conn = conn
   )
 }
 
@@ -240,9 +312,14 @@ nrp_add_sites <- function(data, db_path = getOption("nrp.db_path", file.choose()
 #' @inheritParams readwritesqlite::rws_write
 #' @export
 #'
-nrp_upload_ctd <- function(data, db_path = getOption("nrp.db_path", file.choose()),
-                           commit = TRUE, strict = TRUE, silent = TRUE,
-                           replace = FALSE) {
+nrp_upload_ctd <- function(
+  data,
+  db_path = getOption("nrp.db_path", file.choose()),
+  commit = TRUE,
+  strict = TRUE,
+  silent = TRUE,
+  replace = FALSE
+) {
   chk::chk_flag(replace)
   chk::chk_flag(commit)
   chk::chk_flag(strict)
@@ -256,20 +333,31 @@ nrp_upload_ctd <- function(data, db_path = getOption("nrp.db_path", file.choose(
 
   check_ctd_data(data, exclusive = TRUE, order = TRUE)
 
-  dup <- stats::aggregate(Retain ~ Date + Time + SiteID, data = data, function(x) length(which(x == FALSE)))
-  first_file <- data[!duplicated(data[c("Date", "Time", "SiteID")]), c("Date", "Time", "SiteID", "File")]
+  dup <- stats::aggregate(
+    Retain ~ Date + Time + SiteID,
+    data = data,
+    function(x) length(which(x == FALSE))
+  )
+  first_file <- data[
+    !duplicated(data[c("Date", "Time", "SiteID")]),
+    c("Date", "Time", "SiteID", "File")
+  ]
   visit <- left_join(dup, first_file, by = c("Date", "Time", "SiteID"))
   names(visit)[names(visit) == "Retain"] <- "DepthDuplicates"
-  visit %<>% select("SiteID", "Date", "Time", "DepthDuplicates", "File") %>%
+  visit %<>%
+    select("SiteID", "Date", "Time", "DepthDuplicates", "File") %>%
     as_tibble()
 
   visit_db <- nrp_download_ctd_visit(db_path = conn)
   visit_upload <- setdiff(visit, visit_db)
 
   readwritesqlite::rws_write(
-    x = visit_upload, commit = commit,
-    strict = strict, silent = silent,
-    x_name = "visitCTD", conn = conn
+    x = visit_upload,
+    commit = commit,
+    strict = strict,
+    silent = silent,
+    x_name = "visitCTD",
+    conn = conn
   )
 
   n_pre_filt <- nrow(data)
@@ -280,9 +368,13 @@ nrp_upload_ctd <- function(data, db_path = getOption("nrp.db_path", file.choose(
   data %<>% select(-"File", -"Retain")
 
   readwritesqlite::rws_write(
-    x = data, commit = commit, strict = strict,
+    x = data,
+    commit = commit,
+    strict = strict,
     silent = silent,
-    x_name = "CTD", conn = conn, replace = replace
+    x_name = "CTD",
+    conn = conn,
+    replace = replace
   )
 }
 
@@ -300,9 +392,13 @@ nrp_upload_ctd <- function(data, db_path = getOption("nrp.db_path", file.choose(
 #' @return CTD data table
 #' @export
 #'
-nrp_download_ctd <- function(start_date = NULL, end_date = NULL,
-                             sites = NULL, parameters = "all",
-                             db_path = getOption("nrp.db_path", file.choose())) {
+nrp_download_ctd <- function(
+  start_date = NULL,
+  end_date = NULL,
+  sites = NULL,
+  parameters = "all",
+  db_path = getOption("nrp.db_path", file.choose())
+) {
   chk::chk_null_or(sites, vld = chk::vld_character)
   chk::chk_character(parameters)
 
@@ -321,10 +417,19 @@ nrp_download_ctd <- function(start_date = NULL, end_date = NULL,
   }
 
   default_parameters <- c(
-    "Depth", "Cast", "Temperature", "Oxygen", "Oxygen2",
-    "Conductivity", "Conductivity2",
-    "Salinity", "Backscatter", "Fluorescence",
-    "Frequency", "Flag", "Pressure"
+    "Depth",
+    "Cast",
+    "Temperature",
+    "Oxygen",
+    "Oxygen2",
+    "Conductivity",
+    "Conductivity2",
+    "Salinity",
+    "Backscatter",
+    "Fluorescence",
+    "Frequency",
+    "Flag",
+    "Pressure"
   )
 
   site_table <- nrp_download_sites(db_path = conn)
@@ -341,7 +446,10 @@ nrp_download_ctd <- function(start_date = NULL, end_date = NULL,
   }
 
   dates <- fill_date_query(
-    table = "CTD", col = "Date", end = end_date, start = start_date,
+    table = "CTD",
+    col = "Date",
+    end = end_date,
+    start = start_date,
     connection = conn
   )
   start_date <- dates["start_date"][[1]]
@@ -362,8 +470,15 @@ nrp_download_ctd <- function(start_date = NULL, end_date = NULL,
   end_dateSql <- paste0("'", end_date, "'")
 
   query <- paste0(
-    "SELECT ", paramsSql, " FROM CTD WHERE ((`Date` >= ", start_dateSql, ") AND (`Date` <= ",
-    end_dateSql, ") AND (`SiteID` IN (", sitesSql, ")))"
+    "SELECT ",
+    paramsSql,
+    " FROM CTD WHERE ((`Date` >= ",
+    start_dateSql,
+    ") AND (`Date` <= ",
+    end_dateSql,
+    ") AND (`SiteID` IN (",
+    sitesSql,
+    ")))"
   )
 
   readwritesqlite::rws_query(query = query, conn = conn, meta = TRUE) %>%

--- a/R/ems.R
+++ b/R/ems.R
@@ -6,7 +6,11 @@
 #' @return A tibble.
 #' @export
 
-nrp_extract_ems <- function(data, db_path = getOption("nrp.db_path", file.choose()), analysis_type = "standard") {
+nrp_extract_ems <- function(
+  data,
+  db_path = getOption("nrp.db_path", file.choose()),
+  analysis_type = "standard"
+) {
   chk::chk_chr(analysis_type)
   if (!analysis_type %in% c("standard", "metals")) {
     err("analysis_type must be either 'standard' or 'metals'")
@@ -27,37 +31,61 @@ nrp_extract_ems <- function(data, db_path = getOption("nrp.db_path", file.choose
 
   params <- nrp::ems_param_lookup
 
-  data %<>% filter(EMS_ID %in% sites$EmsSiteNumber) %>%
+  data %<>%
+    filter(EMS_ID %in% sites$EmsSiteNumber) %>%
     mutate(
       COLLECTION_START = lubridate::ymd_hms(COLLECTION_START, tz = "Etc/GMT+8"),
       COLLECTION_END = lubridate::ymd_hms(COLLECTION_END, tz = "Etc/GMT+8")
     ) %>%
     select(
-      EMS_ID, MONITORING_LOCATION, COLLECTION_START, COLLECTION_END, REQUISITION_ID,
-      PARAMETER, RESULT, ANALYZING_AGENCY, RESULT_LETTER, UPPER_DEPTH,
-      LOWER_DEPTH, ANALYTICAL_METHOD, UNIT
+      EMS_ID,
+      MONITORING_LOCATION,
+      COLLECTION_START,
+      COLLECTION_END,
+      REQUISITION_ID,
+      PARAMETER,
+      RESULT,
+      ANALYZING_AGENCY,
+      RESULT_LETTER,
+      UPPER_DEPTH,
+      LOWER_DEPTH,
+      ANALYTICAL_METHOD,
+      UNIT
     ) %>%
-    mutate(PARAMETER = ifelse(PARAMETER %in% c("Phosphorus Total Dissolved") &
-      ANALYTICAL_METHOD == "ICP",
-    "Phosphorus Total Dissolved metals", PARAMETER
-    )) %>%
-    mutate(PARAMETER = ifelse(PARAMETER == "Phosphorus Total" &
-      ANALYTICAL_METHOD == "Total Metals in Water by ICPMS (Ultra)",
-    "Phosphorus Total metals", PARAMETER
-    )) %>%
+    mutate(
+      PARAMETER = ifelse(
+        PARAMETER %in%
+          c("Phosphorus Total Dissolved") &
+          ANALYTICAL_METHOD == "ICP",
+        "Phosphorus Total Dissolved metals",
+        PARAMETER
+      )
+    ) %>%
+    mutate(
+      PARAMETER = ifelse(
+        PARAMETER == "Phosphorus Total" &
+          ANALYTICAL_METHOD == "Total Metals in Water by ICPMS (Ultra)",
+        "Phosphorus Total metals",
+        PARAMETER
+      )
+    ) %>%
     mutate(
       RESULT_LETTER = gsub("M", NA, RESULT_LETTER),
       RESULT = paste0(RESULT, "/", RESULT_LETTER),
       RESULT = gsub(c("NA"), "", RESULT)
     ) %>%
     select(-ANALYTICAL_METHOD, -RESULT_LETTER, -EMS_ID) %>%
-    left_join(select(sites, SiteID, EmsSiteName), by = c("MONITORING_LOCATION" = "EmsSiteName")) %>%
+    left_join(
+      select(sites, SiteID, EmsSiteName),
+      by = c("MONITORING_LOCATION" = "EmsSiteName")
+    ) %>%
     select(-MONITORING_LOCATION)
 
   if (analysis_type == "standard") {
     params_standard <- params$PARAMETER[params$Comment == "standard analysis"]
 
-    data %<>% filter(PARAMETER %in% params_standard) %>%
+    data %<>%
+      filter(PARAMETER %in% params_standard) %>%
       mutate(
         PARAMETER = paste0(PARAMETER, "unit:", UNIT),
         REQUISITION_ID = as.numeric(REQUISITION_ID)
@@ -69,44 +97,84 @@ nrp_extract_ems <- function(data, db_path = getOption("nrp.db_path", file.choose
       tidyr::spread(key = PARAMETER, value = RESULT, fill = NA) %>%
       arrange(COLLECTION_START)
 
-
     key_cols <- c(
-      "SiteID", "COLLECTION_START", "COLLECTION_END", "REQUISITION_ID",
-      "ANALYZING_AGENCY", "UPPER_DEPTH", "LOWER_DEPTH"
+      "SiteID",
+      "COLLECTION_START",
+      "COLLECTION_END",
+      "REQUISITION_ID",
+      "ANALYZING_AGENCY",
+      "UPPER_DEPTH",
+      "LOWER_DEPTH"
     )
 
     data %<>% clean_key_cols(key_cols)
 
-    data %<>% group_by(
-      SiteID, COLLECTION_START, COLLECTION_END, REQUISITION_ID,
-      ANALYZING_AGENCY, UPPER_DEPTH, LOWER_DEPTH
-    ) %>%
+    data %<>%
+      group_by(
+        SiteID,
+        COLLECTION_START,
+        COLLECTION_END,
+        REQUISITION_ID,
+        ANALYZING_AGENCY,
+        UPPER_DEPTH,
+        LOWER_DEPTH
+      ) %>%
       mutate(ReplicateID = seq_len(n())) %>%
       ungroup()
 
     data %<>% add_ems_detection_limit_cols(params = params_standard)
     standard_units <- pull_ems_units(data)
     names(data) <- gsub("unit:.*", "", names(data))
-    data %<>% map2_dfc(standard_units, fill_units) %>%
+    data %<>%
+      map2_dfc(standard_units, fill_units) %>%
       select(
-        `SiteID`, `COLLECTION_START`, `COLLECTION_END`, `REQUISITION_ID`, `ANALYZING_AGENCY`,
-        `UPPER_DEPTH`, `LOWER_DEPTH`, `ReplicateID`, `Alkalinity Total 4.5`,
-        `Limit Alkalinity Total 4.5`, `Carbon Total Inorganic`, `Limit Carbon Total Inorganic`,
-        `Carbon Total Organic`, `Limit Carbon Total Organic`, `Carbon Total`,
-        `Limit Carbon Total`, `Chlorophyll A`, `Limit Chlorophyll A`, `Nitrate (NO3) Dissolved`,
-        `Limit Nitrate (NO3) Dissolved`, `Nitrate(NO3) + Nitrite(NO2) Dissolved`,
-        `Limit Nitrate(NO3) + Nitrite(NO2) Dissolved`, `Nitrogen - Nitrite Dissolved (NO2)`,
-        `Limit Nitrogen - Nitrite Dissolved (NO2)`, `Nitrogen Ammonia Total`,
-        `Limit Nitrogen Ammonia Total`, `Nitrogen Total`,
-        `Limit Nitrogen Total`, `Phosphorus Ort.Dis-P`, `Limit Phosphorus Ort.Dis-P`,
-        `Phosphorus Total Dissolved`, `Limit Phosphorus Total Dissolved`, `Phosphorus Total`,
-        `Limit Phosphorus Total`, `pH`, `Limit pH`, `Silica Reactive Diss`,
-        `Limit Silica Reactive Diss`, `Turbidity`, `Limit Turbidity`, row_id
+        `SiteID`,
+        `COLLECTION_START`,
+        `COLLECTION_END`,
+        `REQUISITION_ID`,
+        `ANALYZING_AGENCY`,
+        `UPPER_DEPTH`,
+        `LOWER_DEPTH`,
+        `ReplicateID`,
+        `Alkalinity Total 4.5`,
+        `Limit Alkalinity Total 4.5`,
+        `Carbon Total Inorganic`,
+        `Limit Carbon Total Inorganic`,
+        `Carbon Total Organic`,
+        `Limit Carbon Total Organic`,
+        `Carbon Total`,
+        `Limit Carbon Total`,
+        `Chlorophyll A`,
+        `Limit Chlorophyll A`,
+        `Nitrate (NO3) Dissolved`,
+        `Limit Nitrate (NO3) Dissolved`,
+        `Nitrate(NO3) + Nitrite(NO2) Dissolved`,
+        `Limit Nitrate(NO3) + Nitrite(NO2) Dissolved`,
+        `Nitrogen - Nitrite Dissolved (NO2)`,
+        `Limit Nitrogen - Nitrite Dissolved (NO2)`,
+        `Nitrogen Ammonia Total`,
+        `Limit Nitrogen Ammonia Total`,
+        `Nitrogen Total`,
+        `Limit Nitrogen Total`,
+        `Phosphorus Ort.Dis-P`,
+        `Limit Phosphorus Ort.Dis-P`,
+        `Phosphorus Total Dissolved`,
+        `Limit Phosphorus Total Dissolved`,
+        `Phosphorus Total`,
+        `Limit Phosphorus Total`,
+        `pH`,
+        `Limit pH`,
+        `Silica Reactive Diss`,
+        `Limit Silica Reactive Diss`,
+        `Turbidity`,
+        `Limit Turbidity`,
+        row_id
       )
   } else if (analysis_type == "metals") {
     params_metals <- params$PARAMETER[params$Comment == "metals"]
 
-    data %<>% filter(PARAMETER %in% params_metals) %>%
+    data %<>%
+      filter(PARAMETER %in% params_metals) %>%
       mutate(
         PARAMETER = paste0(PARAMETER, "unit:", UNIT),
         REQUISITION_ID = as.numeric(REQUISITION_ID)
@@ -123,14 +191,25 @@ nrp_extract_ems <- function(data, db_path = getOption("nrp.db_path", file.choose
     }
 
     key_cols <- c(
-      "SiteID", "COLLECTION_START", "COLLECTION_END", "REQUISITION_ID",
-      "ANALYZING_AGENCY", "UPPER_DEPTH", "LOWER_DEPTH"
+      "SiteID",
+      "COLLECTION_START",
+      "COLLECTION_END",
+      "REQUISITION_ID",
+      "ANALYZING_AGENCY",
+      "UPPER_DEPTH",
+      "LOWER_DEPTH"
     )
 
-    data %<>% clean_key_cols(key_cols) %>%
+    data %<>%
+      clean_key_cols(key_cols) %>%
       group_by(
-        SiteID, COLLECTION_START, COLLECTION_END, REQUISITION_ID,
-        ANALYZING_AGENCY, UPPER_DEPTH, LOWER_DEPTH
+        SiteID,
+        COLLECTION_START,
+        COLLECTION_END,
+        REQUISITION_ID,
+        ANALYZING_AGENCY,
+        UPPER_DEPTH,
+        LOWER_DEPTH
       ) %>%
       mutate(ReplicateID = seq_len(n())) %>%
       ungroup()
@@ -139,61 +218,176 @@ nrp_extract_ems <- function(data, db_path = getOption("nrp.db_path", file.choose
     metals_units <- pull_ems_units(data)
     names(data) <- gsub("unit:.*", "", names(data))
     data %<>% map2_dfc(metals_units, fill_units)
-    data %<>% select(
-      SiteID, COLLECTION_START, COLLECTION_END, REQUISITION_ID, ANALYZING_AGENCY,
-      UPPER_DEPTH, LOWER_DEPTH, ReplicateID, `Alkalinity Phen. 8.3`,
-      `Limit Alkalinity Phen. 8.3`, `Aluminum Dissolved`, `Limit Aluminum Dissolved`,
-      `Aluminum Total`, `Limit Aluminum Total`, `Antimony Dissolved`,
-      `Limit Antimony Dissolved`, `Antimony Total`, `Limit Antimony Total`,
-      `Arsenic Dissolved`, `Limit Arsenic Dissolved`, `Arsenic Total`, `Limit Arsenic Total`,
-      `Barium Dissolved`, `Limit Barium Dissolved`, `Barium Total`, `Limit Barium Total`,
-      `Beryllium Dissolved`, `Limit Beryllium Dissolved`, `Beryllium Total`,
-      `Limit Beryllium Total`, `Bicarbonate Alkalinity`, `Limit Bicarbonate Alkalinity`,
-      `Bismuth Dissolved`, `Limit Bismuth Dissolved`, `Bismuth Total`, `Limit Bismuth Total`,
-      `Boron Dissolved`, `Limit Boron Dissolved`, `Boron Total`, `Limit Boron Total`,
-      `Cadmium Dissolved`, `Limit Cadmium Dissolved`, `Cadmium Total`, `Limit Cadmium Total`,
-      `Calcium Dissolved`, `Limit Calcium Dissolved`, `Calcium Total`, `Limit Calcium Total`,
-      `Carbonate Alkalinity`, `Limit Carbonate Alkalinity`, `Chromium Dissolved`,
-      `Limit Chromium Dissolved`, `Chromium Total`, `Limit Chromium Total`,
-      `Cobalt Dissolved`, `Limit Cobalt Dissolved`, `Cobalt Total`, `Limit Cobalt Total`,
-      `Copper Dissolved`, `Limit Copper Dissolved`, `Copper Total`, `Limit Copper Total`,
-      `Hardness (Dissolved)`, `Limit Hardness (Dissolved)`, `Hardness Total (Total)`,
-      `Limit Hardness Total (Total)`, `Hydroxide Alkalinity`, `Limit Hydroxide Alkalinity`,
-      `Iron Dissolved`, `Limit Iron Dissolved`, `Iron Total`, `Limit Iron Total`,
-      `Lead Dissolved`, `Limit Lead Dissolved`, `Lead Total`, `Limit Lead Total`,
-      `Magnesium Dissolved`, `Limit Magnesium Dissolved`, `Magnesium Total`,
-      `Limit Magnesium Total`, `Manganese Dissolved`, `Limit Manganese Dissolved`,
-      `Manganese Total`, `Limit Manganese Total`, `Molybdenum Dissolved`,
-      `Limit Molybdenum Dissolved`, `Molybdenum Total`, `Limit Molybdenum Total`,
-      `Nickel Dissolved`, `Limit Nickel Dissolved`, `Nickel Total`, `Limit Nickel Total`,
-      `Phosphorus Total Dissolved metals`, `Limit Phosphorus Total Dissolved metals`,
-      `Phosphorus Total metals`, `Limit Phosphorus Total metals`, `Potassium Dissolved`,
-      `Limit Potassium Dissolved`, `Potassium Total`, `Limit Potassium Total`,
-      `Selenium Dissolved`, `Limit Selenium Dissolved`, `Selenium Total`,
-      `Limit Selenium Total`, `Silicon Dissolved`, `Limit Silicon Dissolved`,
-      `Silicon Total`, `Limit Silicon Total`, `Silver Dissolved`, `Limit Silver Dissolved`,
-      `Silver Total`, `Limit Silver Total`, `Sodium Dissolved`, `Limit Sodium Dissolved`,
-      `Sodium Total`, `Limit Sodium Total`, `Strontium Dissolved`, `Limit Strontium Dissolved`,
-      `Strontium Total`, `Limit Strontium Total`, `Sulfur Dissolved`,
-      `Limit Sulfur Dissolved`, `Sulfur Total`, `Limit Sulfur Total`, `Thallium Dissolved`,
-      `Limit Thallium Dissolved`, `Thallium Total`, `Limit Thallium Total`, `Tin Dissolved`,
-      `Limit Tin Dissolved`, `Tin Total`, `Limit Tin Total`, `Titanium Dissolved`,
-      `Limit Titanium Dissolved`, `Titanium Total`, `Limit Titanium Total`,
-      `Uranium Dissolved`, `Limit Uranium Dissolved`, `Uranium Total`, `Limit Uranium Total`,
-      `Vanadium Dissolved`, `Limit Vanadium Dissolved`, `Vanadium Total`,
-      `Limit Vanadium Total`, `Zinc Dissolved`, `Limit Zinc Dissolved`, `Zinc Total`,
-      `Limit Zinc Total`, row_id
-    )
+    data %<>%
+      select(
+        SiteID,
+        COLLECTION_START,
+        COLLECTION_END,
+        REQUISITION_ID,
+        ANALYZING_AGENCY,
+        UPPER_DEPTH,
+        LOWER_DEPTH,
+        ReplicateID,
+        `Alkalinity Phen. 8.3`,
+        `Limit Alkalinity Phen. 8.3`,
+        `Aluminum Dissolved`,
+        `Limit Aluminum Dissolved`,
+        `Aluminum Total`,
+        `Limit Aluminum Total`,
+        `Antimony Dissolved`,
+        `Limit Antimony Dissolved`,
+        `Antimony Total`,
+        `Limit Antimony Total`,
+        `Arsenic Dissolved`,
+        `Limit Arsenic Dissolved`,
+        `Arsenic Total`,
+        `Limit Arsenic Total`,
+        `Barium Dissolved`,
+        `Limit Barium Dissolved`,
+        `Barium Total`,
+        `Limit Barium Total`,
+        `Beryllium Dissolved`,
+        `Limit Beryllium Dissolved`,
+        `Beryllium Total`,
+        `Limit Beryllium Total`,
+        `Bicarbonate Alkalinity`,
+        `Limit Bicarbonate Alkalinity`,
+        `Bismuth Dissolved`,
+        `Limit Bismuth Dissolved`,
+        `Bismuth Total`,
+        `Limit Bismuth Total`,
+        `Boron Dissolved`,
+        `Limit Boron Dissolved`,
+        `Boron Total`,
+        `Limit Boron Total`,
+        `Cadmium Dissolved`,
+        `Limit Cadmium Dissolved`,
+        `Cadmium Total`,
+        `Limit Cadmium Total`,
+        `Calcium Dissolved`,
+        `Limit Calcium Dissolved`,
+        `Calcium Total`,
+        `Limit Calcium Total`,
+        `Carbonate Alkalinity`,
+        `Limit Carbonate Alkalinity`,
+        `Chromium Dissolved`,
+        `Limit Chromium Dissolved`,
+        `Chromium Total`,
+        `Limit Chromium Total`,
+        `Cobalt Dissolved`,
+        `Limit Cobalt Dissolved`,
+        `Cobalt Total`,
+        `Limit Cobalt Total`,
+        `Copper Dissolved`,
+        `Limit Copper Dissolved`,
+        `Copper Total`,
+        `Limit Copper Total`,
+        `Hardness (Dissolved)`,
+        `Limit Hardness (Dissolved)`,
+        `Hardness Total (Total)`,
+        `Limit Hardness Total (Total)`,
+        `Hydroxide Alkalinity`,
+        `Limit Hydroxide Alkalinity`,
+        `Iron Dissolved`,
+        `Limit Iron Dissolved`,
+        `Iron Total`,
+        `Limit Iron Total`,
+        `Lead Dissolved`,
+        `Limit Lead Dissolved`,
+        `Lead Total`,
+        `Limit Lead Total`,
+        `Magnesium Dissolved`,
+        `Limit Magnesium Dissolved`,
+        `Magnesium Total`,
+        `Limit Magnesium Total`,
+        `Manganese Dissolved`,
+        `Limit Manganese Dissolved`,
+        `Manganese Total`,
+        `Limit Manganese Total`,
+        `Molybdenum Dissolved`,
+        `Limit Molybdenum Dissolved`,
+        `Molybdenum Total`,
+        `Limit Molybdenum Total`,
+        `Nickel Dissolved`,
+        `Limit Nickel Dissolved`,
+        `Nickel Total`,
+        `Limit Nickel Total`,
+        `Phosphorus Total Dissolved metals`,
+        `Limit Phosphorus Total Dissolved metals`,
+        `Phosphorus Total metals`,
+        `Limit Phosphorus Total metals`,
+        `Potassium Dissolved`,
+        `Limit Potassium Dissolved`,
+        `Potassium Total`,
+        `Limit Potassium Total`,
+        `Selenium Dissolved`,
+        `Limit Selenium Dissolved`,
+        `Selenium Total`,
+        `Limit Selenium Total`,
+        `Silicon Dissolved`,
+        `Limit Silicon Dissolved`,
+        `Silicon Total`,
+        `Limit Silicon Total`,
+        `Silver Dissolved`,
+        `Limit Silver Dissolved`,
+        `Silver Total`,
+        `Limit Silver Total`,
+        `Sodium Dissolved`,
+        `Limit Sodium Dissolved`,
+        `Sodium Total`,
+        `Limit Sodium Total`,
+        `Strontium Dissolved`,
+        `Limit Strontium Dissolved`,
+        `Strontium Total`,
+        `Limit Strontium Total`,
+        `Sulfur Dissolved`,
+        `Limit Sulfur Dissolved`,
+        `Sulfur Total`,
+        `Limit Sulfur Total`,
+        `Thallium Dissolved`,
+        `Limit Thallium Dissolved`,
+        `Thallium Total`,
+        `Limit Thallium Total`,
+        `Tin Dissolved`,
+        `Limit Tin Dissolved`,
+        `Tin Total`,
+        `Limit Tin Total`,
+        `Titanium Dissolved`,
+        `Limit Titanium Dissolved`,
+        `Titanium Total`,
+        `Limit Titanium Total`,
+        `Uranium Dissolved`,
+        `Limit Uranium Dissolved`,
+        `Uranium Total`,
+        `Limit Uranium Total`,
+        `Vanadium Dissolved`,
+        `Limit Vanadium Dissolved`,
+        `Vanadium Total`,
+        `Limit Vanadium Total`,
+        `Zinc Dissolved`,
+        `Limit Zinc Dissolved`,
+        `Zinc Total`,
+        `Limit Zinc Total`,
+        row_id
+      )
   }
 
-  data %<>% mutate(
-    LOWER_DEPTH = units::set_units(as.numeric(LOWER_DEPTH), "m"),
-    UPPER_DEPTH = units::set_units(as.numeric(UPPER_DEPTH), "m")
-  ) %>%
+  data %<>%
+    mutate(
+      LOWER_DEPTH = units::set_units(as.numeric(LOWER_DEPTH), "m"),
+      UPPER_DEPTH = units::set_units(as.numeric(UPPER_DEPTH), "m")
+    ) %>%
     select(
-      SiteID, COLLECTION_START, COLLECTION_END, REQUISITION_ID,
-      ANALYZING_AGENCY, UPPER_DEPTH, LOWER_DEPTH, ReplicateID,
-      everything(), -row_id
+      SiteID,
+      COLLECTION_START,
+      COLLECTION_END,
+      REQUISITION_ID,
+      ANALYZING_AGENCY,
+      UPPER_DEPTH,
+      LOWER_DEPTH,
+      ReplicateID,
+      everything(),
+      -row_id
     )
   data
 }
@@ -204,25 +398,48 @@ add_ems_detection_limit_cols <- function(data, params, sep = "/") {
     if (grepl("limit", name)) {
       next()
     } else if (base_name %in% params) {
-      data %<>% tidyr::separate(name, c(paste("value", name), paste("Limit", name)), sep = sep) %>%
-        mutate_at(vars(paste("Limit", name)), list(~ if_else(eval(parse(text = paste0("`", "Limit ", name, "`"))) == "<",
-          eval(parse(text = paste0("`", "Limit ", name, "`"))),
-          NA_character_
-        ))) %>%
+      data %<>%
+        tidyr::separate(
+          name,
+          c(paste("value", name), paste("Limit", name)),
+          sep = sep
+        ) %>%
         mutate_at(
           vars(paste("Limit", name)),
-          list(~ if_else(eval(parse(text = paste0("`", "Limit ", name, "`"))) == "<",
-            eval(parse(text = paste0("`", "value ", name, "`"))),
-            eval(parse(text = paste0("`", "Limit ", name, "`")))
-          ))
+          list(
+            ~ if_else(
+              eval(parse(text = paste0("`", "Limit ", name, "`"))) == "<",
+              eval(parse(text = paste0("`", "Limit ", name, "`"))),
+              NA_character_
+            )
+          )
+        ) %>%
+        mutate_at(
+          vars(paste("Limit", name)),
+          list(
+            ~ if_else(
+              eval(parse(text = paste0("`", "Limit ", name, "`"))) == "<",
+              eval(parse(text = paste0("`", "value ", name, "`"))),
+              eval(parse(text = paste0("`", "Limit ", name, "`")))
+            )
+          )
         ) %>%
         mutate_at(
           vars(paste("value", name)),
-          list(~ if_else(!is.na(eval(parse(text = paste0("`", "Limit ", name, "`")))),
-            0, as.numeric(eval(parse(text = paste0("`", "value ", name, "`"))))
-          ))
+          list(
+            ~ if_else(
+              !is.na(eval(parse(text = paste0("`", "Limit ", name, "`")))),
+              0,
+              as.numeric(eval(parse(text = paste0("`", "value ", name, "`"))))
+            )
+          )
         ) %>%
-        mutate_at(vars(paste("Limit", name)), list(~ as.numeric(eval(parse(text = paste0("`", "Limit ", name, "`"))))))
+        mutate_at(
+          vars(paste("Limit", name)),
+          list(
+            ~ as.numeric(eval(parse(text = paste0("`", "Limit ", name, "`"))))
+          )
+        )
     }
   }
   names(data) <- gsub("value ", "", names(data))
@@ -235,8 +452,14 @@ add_ems_detection_limit_cols <- function(data, params, sep = "/") {
 #' @param db_path An Sqlite Database Connection, or path to an SQLite Database
 #' @inheritParams readwritesqlite::rws_write
 #' @export
-nrp_upload_ems_standard <- function(data, db_path = getOption("nrp.db_path", file.choose()), commit = TRUE,
-                                    strict = TRUE, silent = TRUE, replace = FALSE) {
+nrp_upload_ems_standard <- function(
+  data,
+  db_path = getOption("nrp.db_path", file.choose()),
+  commit = TRUE,
+  strict = TRUE,
+  silent = TRUE,
+  replace = FALSE
+) {
   chk::chk_flag(replace)
   chk::chk_flag(commit)
   chk::chk_flag(strict)
@@ -256,30 +479,44 @@ nrp_upload_ems_standard <- function(data, db_path = getOption("nrp.db_path", fil
 
     if (!nrow(result) == 0) {
       last_date <- result[[1, 1]]
-      date_4yr <- dttr2::dtt_date_time(as.numeric(last_date) - 126316800, tz = "Etc/GMT+8")
+      date_4yr <- dttr2::dtt_date_time(
+        as.numeric(last_date) - 126316800,
+        tz = "Etc/GMT+8"
+      )
       query <- paste0(
-        "SELECT * FROM standardEMS WHERE ((`COLLECTION_START` >= '", date_4yr, "') AND (`COLLECTION_START` <= '",
-        last_date, "'))"
+        "SELECT * FROM standardEMS WHERE ((`COLLECTION_START` >= '",
+        date_4yr,
+        "') AND (`COLLECTION_START` <= '",
+        last_date,
+        "'))"
       )
       ems_4year <- readwritesqlite::rws_query(query = query, conn = conn)
 
-      data %<>% setdiff(ems_4year) %>%
-        filter(COLLECTION_START > last_date)
+      data %<>% setdiff(ems_4year) %>% filter(COLLECTION_START > last_date)
 
       if (nrow(data) == 0) {
         err("The data you are attempting to upload is already in the database")
       } else {
         message(paste(
-          "Trimmed new data.", nrow(data), "new rows to be included in upload for date range",
-          first(data$COLLECTION_START), "-", last(data$COLLECTION_START)
+          "Trimmed new data.",
+          nrow(data),
+          "new rows to be included in upload for date range",
+          first(data$COLLECTION_START),
+          "-",
+          last(data$COLLECTION_START)
         ))
       }
     }
   }
 
   readwritesqlite::rws_write(
-    x = data, commit = commit, strict = strict, silent = silent,
-    replace = replace, x_name = "standardEMS", conn = conn
+    x = data,
+    commit = commit,
+    strict = strict,
+    silent = silent,
+    replace = replace,
+    x_name = "standardEMS",
+    conn = conn
   )
 }
 
@@ -291,8 +528,14 @@ nrp_upload_ems_standard <- function(data, db_path = getOption("nrp.db_path", fil
 #' @param db_path An Sqlite Database Connection, or path to an SQLite Database
 #' @inheritParams readwritesqlite::rws_write
 #' @export
-nrp_upload_ems_metals <- function(data, db_path = getOption("nrp.db_path", file.choose()), commit = TRUE,
-                                  strict = TRUE, silent = TRUE, replace = FALSE) {
+nrp_upload_ems_metals <- function(
+  data,
+  db_path = getOption("nrp.db_path", file.choose()),
+  commit = TRUE,
+  strict = TRUE,
+  silent = TRUE,
+  replace = FALSE
+) {
   chk::chk_flag(replace)
   chk::chk_flag(commit)
   chk::chk_flag(strict)
@@ -312,29 +555,43 @@ nrp_upload_ems_metals <- function(data, db_path = getOption("nrp.db_path", file.
 
     if (!nrow(result) == 0) {
       last_date <- result[[1, 1]]
-      date_4yr <- dttr2::dtt_date_time(as.numeric(last_date) - 126316800, tz = "Etc/GMT+8")
+      date_4yr <- dttr2::dtt_date_time(
+        as.numeric(last_date) - 126316800,
+        tz = "Etc/GMT+8"
+      )
       query <- paste0(
-        "SELECT * FROM metalsEMS WHERE ((`COLLECTION_START` >= '", date_4yr, "') AND (`COLLECTION_START` <= '",
-        last_date, "'))"
+        "SELECT * FROM metalsEMS WHERE ((`COLLECTION_START` >= '",
+        date_4yr,
+        "') AND (`COLLECTION_START` <= '",
+        last_date,
+        "'))"
       )
       ems_4year <- readwritesqlite::rws_query(query = query, conn = conn)
 
-      data %<>% setdiff(ems_4year) %>%
-        filter(COLLECTION_START > last_date)
+      data %<>% setdiff(ems_4year) %>% filter(COLLECTION_START > last_date)
 
       if (nrow(data) == 0) {
         err("The data you are attempting to upload is already in the database")
       } else {
         message(paste(
-          "Trimmed new data.", nrow(data), "new rows to be included in upload for date range",
-          first(data$COLLECTION_START), "-", last(data$COLLECTION_START)
+          "Trimmed new data.",
+          nrow(data),
+          "new rows to be included in upload for date range",
+          first(data$COLLECTION_START),
+          "-",
+          last(data$COLLECTION_START)
         ))
       }
     }
   }
   readwritesqlite::rws_write(
-    x = data, commit = commit, strict = strict, silent = silent,
-    replace = replace, x_name = "metalsEMS", conn = conn
+    x = data,
+    commit = commit,
+    strict = strict,
+    silent = silent,
+    replace = replace,
+    x_name = "metalsEMS",
+    conn = conn
   )
 }
 
@@ -348,9 +605,14 @@ nrp_upload_ems_metals <- function(data, db_path = getOption("nrp.db_path", file.
 #' @param show_detection_limits Whether to include detection limit columns for each parameter
 #' @return EMS data table
 #' @export
-nrp_download_ems <- function(db_path = getOption("nrp.db_path", file.choose()), start_date_time = NULL,
-                             end_date_time = NULL, sites = NULL, analysis_type = "standard",
-                             show_detection_limits = FALSE) {
+nrp_download_ems <- function(
+  db_path = getOption("nrp.db_path", file.choose()),
+  start_date_time = NULL,
+  end_date_time = NULL,
+  sites = NULL,
+  analysis_type = "standard",
+  show_detection_limits = FALSE
+) {
   chk::chk_null_or(start_date_time, chk = check_chr_date)
   chk::chk_null_or(end_date_time, chk = check_chr_date)
   chk::chk_chr(analysis_type)
@@ -382,7 +644,10 @@ nrp_download_ems <- function(db_path = getOption("nrp.db_path", file.choose()), 
   }
 
   dates <- fill_date_time_query(
-    table = table, col = "COLLECTION_START", end = end_date_time, start = start_date_time,
+    table = table,
+    col = "COLLECTION_START",
+    end = end_date_time,
+    start = start_date_time,
     connection = conn
   )
   start_date <- dates["start_date_time"][[1]]
@@ -397,8 +662,15 @@ nrp_download_ems <- function(db_path = getOption("nrp.db_path", file.choose()), 
   end_dateSql <- paste0("'", end_date_time, "'")
 
   query <- paste0(
-    "SELECT * FROM ", table, " WHERE ((`COLLECTION_START` >= ", start_dateSql, ") AND (`COLLECTION_START` <= ",
-    end_dateSql, ") AND (`SiteID` IN (", sitesSql, ")))"
+    "SELECT * FROM ",
+    table,
+    " WHERE ((`COLLECTION_START` >= ",
+    start_dateSql,
+    ") AND (`COLLECTION_START` <= ",
+    end_dateSql,
+    ") AND (`SiteID` IN (",
+    sitesSql,
+    ")))"
   )
 
   result <- readwritesqlite::rws_query(query = query, conn = conn) %>%

--- a/R/internal.R
+++ b/R/internal.R
@@ -10,24 +10,42 @@ all_na <- function(data) {
 
 fill_date_query <- function(table, col, end, start, connection) {
   if (is.null(start) && is.null(end)) {
-    end <- DBI::dbGetQuery(connection, paste0("SELECT MAX(`", col, "`) FROM ", table))[1, 1]
+    end <- DBI::dbGetQuery(
+      connection,
+      paste0("SELECT MAX(`", col, "`) FROM ", table)
+    )[1, 1]
     start <- as.character(dttr2::dtt_add_years(dttr2::dtt_date(end), -1))
   } else if (is.null(start) && !is.null(end)) {
-    start <- DBI::dbGetQuery(connection, paste0("SELECT MIN(`", col, "`) FROM ", table))[1, 1]
+    start <- DBI::dbGetQuery(
+      connection,
+      paste0("SELECT MIN(`", col, "`) FROM ", table)
+    )[1, 1]
   } else if (!is.null(start) && is.null(end)) {
-    end <- DBI::dbGetQuery(connection, paste0("SELECT MAX(`", col, "`) FROM ", table))[1, 1]
+    end <- DBI::dbGetQuery(
+      connection,
+      paste0("SELECT MAX(`", col, "`) FROM ", table)
+    )[1, 1]
   }
   c("start_date" = start, "end_date" = end)
 }
 
 fill_date_time_query <- function(table, col, end, start, connection) {
   if (is.null(start) && is.null(end)) {
-    end <- DBI::dbGetQuery(connection, paste0("SELECT MAX(`", col, "`) FROM ", table))[1, 1]
+    end <- DBI::dbGetQuery(
+      connection,
+      paste0("SELECT MAX(`", col, "`) FROM ", table)
+    )[1, 1]
     start <- as.character(dttr2::dtt_add_years(dttr2::dtt_date_time(end), -1))
   } else if (is.null(start) && !is.null(end)) {
-    start <- DBI::dbGetQuery(connection, paste0("SELECT MIN(`", col, "`) FROM ", table))[1, 1]
+    start <- DBI::dbGetQuery(
+      connection,
+      paste0("SELECT MIN(`", col, "`) FROM ", table)
+    )[1, 1]
   } else if (!is.null(start) && is.null(end)) {
-    end <- DBI::dbGetQuery(connection, paste0("SELECT MAX(`", col, "`) FROM ", table))[1, 1]
+    end <- DBI::dbGetQuery(
+      connection,
+      paste0("SELECT MAX(`", col, "`) FROM ", table)
+    )[1, 1]
   }
   c("start_date_time" = start, "end_date_time" = end)
 }
@@ -63,18 +81,34 @@ clean_input_cols <- function(data, lookup) {
         tryCatch(
           warning = function(w) {
             if (str_detect(w$message, "NAs introduced by coercion")) {
-              err("Ivalid date format for column: '", x, "'.please ensure column is formatted as 'date' (yyyy-mm-dd) in Excel.")
+              err(
+                "Ivalid date format for column: '",
+                x,
+                "'.please ensure column is formatted as 'date' (yyyy-mm-dd) in Excel."
+              )
             }
             dttr2::dtt_date(as.integer(col), origin = "1899-12-30") %>%
               suppressWarnings()
           },
-          error = function(e) err("Ivalid date format for column: '", x, "'. Please ensure column is formatted as 'date' (yyyy-mm-dd) in Excel.")
+          error = function(e) {
+            err(
+              "Ivalid date format for column: '",
+              x,
+              "'. Please ensure column is formatted as 'date' (yyyy-mm-dd) in Excel."
+            )
+          }
         )
     } else {
       col <- methods::as(col, new_class) %>%
         tryCatch(warning = function(w) {
           if (str_detect(w$message, "NAs introduced by coercion")) {
-            err("NAs introduced when cleaning data columns. Please Ensure all values in excel column: '", x, "' are type: '", new_class, "'.")
+            err(
+              "NAs introduced when cleaning data columns. Please Ensure all values in excel column: '",
+              x,
+              "' are type: '",
+              new_class,
+              "'."
+            )
           }
           methods::as(col, new_class) %>% suppressWarnings()
         })
@@ -95,14 +129,20 @@ nrp_install_unit <- function(x) {
     suppressWarnings() %>%
     try(silent = TRUE)
 
-  if (length(result) && !str_detect(result, "already maps to existing but different unit")) {
+  if (
+    length(result) &&
+      !str_detect(result, "already maps to existing but different unit")
+  ) {
     err("Unit", x, " could not be installed.")
   }
 }
 
 paste_vec <- function(x) paste0("'", unique(x), "'", collapse = ", ")
 
-ask_user <- function(msg, auto_yes = getOption("nrp.ask_user.auto_yes", FALSE)) {
+ask_user <- function(
+  msg,
+  auto_yes = getOption("nrp.ask_user.auto_yes", FALSE)
+) {
   chk::chk_chr(msg)
   chk::chk_flag(auto_yes)
 

--- a/R/mysid.R
+++ b/R/mysid.R
@@ -6,10 +6,14 @@
 #' @return A tibble
 #' @export
 #'
-nrp_read_mysid_file <- function(path, db_path = getOption(
-                                  "nrp.db_path",
-                                  file.choose()
-                                ), system = NULL) {
+nrp_read_mysid_file <- function(
+  path,
+  db_path = getOption(
+    "nrp.db_path",
+    file.choose()
+  ),
+  system = NULL
+) {
   check_file_exists(path)
   chk::chk_null_or(system, chk = chk::chk_chr)
 
@@ -19,11 +23,15 @@ nrp_read_mysid_file <- function(path, db_path = getOption(
     } else if (str_detect(tolower(basename(path)), "^kl")) {
       system <- "KL"
     } else {
-      err("'system' cannot be detected from file name. Please set system argument to 'arrow' or 'kootenay'.")
+      err(
+        "'system' cannot be detected from file name. Please set system argument to 'arrow' or 'kootenay'."
+      )
     }
   } else {
     system <- tolower(system)
-    if (!system %in% c("arrow", "kootenay")) err("'system' must be one of 'arrow', 'kootenay'.")
+    if (!system %in% c("arrow", "kootenay")) {
+      err("'system' must be one of 'arrow', 'kootenay'.")
+    }
     system <- ifelse(system == "arrow", "AR", "KL")
   }
 
@@ -49,7 +57,11 @@ nrp_read_mysid_file <- function(path, db_path = getOption(
 
   sites <- nrp_download_sites(db_path = db_path)
 
-  if (!all(unique(data$Station) %in% sites$SiteID)) warning("Sites present in input data that are not found in 'Sites' table in database.")
+  if (!all(unique(data$Station) %in% sites$SiteID)) {
+    warning(
+      "Sites present in input data that are not found in 'Sites' table in database."
+    )
+  }
 
   data
 }
@@ -63,24 +75,35 @@ nrp_read_mysid_file <- function(path, db_path = getOption(
 #' @return A tibble.
 #' @export
 #'
-nrp_read_mysid <- function(path = ".", db_path = getOption("nrp.db_path", file.choose()),
-                           recursive = FALSE, system = NULL, regexp = "[.]xlsx$",
-                           fail = TRUE) {
+nrp_read_mysid <- function(
+  path = ".",
+  db_path = getOption("nrp.db_path", file.choose()),
+  recursive = FALSE,
+  system = NULL,
+  regexp = "[.]xlsx$",
+  fail = TRUE
+) {
   check_dir_exists(path)
   chk::chk_null_or(system, chk = chk::chk_character)
   chk::chk_chr(regexp)
   chk::chk_flag(recursive)
   chk::chk_flag(fail)
 
-  paths <- dir_ls(path,
-    type = "file", recurse = recursive, regexp = regexp,
+  paths <- dir_ls(
+    path,
+    type = "file",
+    recurse = recursive,
+    regexp = regexp,
     fail = fail
   )
   if (!length(paths)) {
     return(named_list())
   }
 
-  datas <- suppressWarnings(do.call("rbind", map(paths, ~ nrp_read_mysid_file(., db_path = db_path, system = system))))
+  datas <- suppressWarnings(do.call(
+    "rbind",
+    map(paths, ~ nrp_read_mysid_file(., db_path = db_path, system = system))
+  ))
   rownames(datas) <- NULL
 
   datas
@@ -93,9 +116,14 @@ nrp_read_mysid <- function(path = ".", db_path = getOption("nrp.db_path", file.c
 #' @inheritParams readwritesqlite::rws_write
 #' @export
 #'
-nrp_upload_mysid <- function(data, db_path = getOption("nrp.db_path", file.choose()),
-                             commit = TRUE, strict = TRUE, silent = TRUE,
-                             replace = FALSE) {
+nrp_upload_mysid <- function(
+  data,
+  db_path = getOption("nrp.db_path", file.choose()),
+  commit = TRUE,
+  strict = TRUE,
+  silent = TRUE,
+  replace = FALSE
+) {
   chk::chk_flag(replace)
   chk::chk_flag(commit)
   chk::chk_flag(strict)
@@ -109,44 +137,100 @@ nrp_upload_mysid <- function(data, db_path = getOption("nrp.db_path", file.choos
 
   check_mysid_raw_data(data, exclusive = TRUE, order = TRUE)
 
-  data %<>% mutate(
-    Date = dttr2::dtt_date(Date),
-    Depth = units::as_units(Depth, "m"),
-    DepthCat = factor(DepthCat, levels = c("Shallow", "Deep"))
+  data %<>%
+    mutate(
+      Date = dttr2::dtt_date(Date),
+      Depth = units::as_units(Depth, "m"),
+      DepthCat = factor(DepthCat, levels = c("Shallow", "Deep"))
+    )
+
+  mysid_sample <- select(
+    data,
+    c(
+      Date,
+      SiteID = Station,
+      Replicate,
+      FileName,
+      MonthCat,
+      Time,
+      Depth,
+      DepthCat,
+      SideLake,
+      SplMade = `#splitsMade`,
+      SplCount = `#splitsCounted`,
+      FundingSource,
+      FieldCollection,
+      Analyst,
+      Comment
+    )
   )
 
-  mysid_sample <- select(data, c(Date,
-    SiteID = Station, Replicate, FileName,
-    MonthCat, Time, Depth, DepthCat,
-    SideLake, SplMade = `#splitsMade`,
-    SplCount = `#splitsCounted`, FundingSource,
-    FieldCollection, Analyst, Comment
-  ))
-
   readwritesqlite::rws_write(
-    x = mysid_sample, commit = commit,
-    strict = strict, silent = silent,
-    x_name = "MysidSample", conn = conn, replace = replace
-  )
-
-  mysid_data <- select(data, c(Date,
-    SiteID = Station, Replicate, DenTotal,
-    Djuv, DimmM, DmatM, DbreedM,
-    DimmF, DmatF, DbroodF, DspentF,
-    DdistBrF, BiomTotal, Bjuv, BimmM,
-    BmatM, BbreedM, BimmF, BmatF,
-    BbroodF, BspentF, BdistBrF, VolDenTotal,
-    VolDjuv, VolDimmM, VolDmatM, VolDbreedM,
-    VolDimmF, VolDmatF, VolDbroodF, VolDspentF,
-    VolDdisBrF, `Eggs/BroodF`, `Eggs/DistBrF`,
-    `Eggs/Total#Mysids`, PropFemGravid
-  )) %>%
-    tidyr::pivot_longer(cols = -c(Date, SiteID, Replicate), names_to = "Parameter", values_to = "Value")
-
-  readwritesqlite::rws_write(
-    x = mysid_data, commit = commit, strict = strict,
+    x = mysid_sample,
+    commit = commit,
+    strict = strict,
     silent = silent,
-    x_name = "Mysid", conn = conn, replace = replace
+    x_name = "MysidSample",
+    conn = conn,
+    replace = replace
+  )
+
+  mysid_data <- select(
+    data,
+    c(
+      Date,
+      SiteID = Station,
+      Replicate,
+      DenTotal,
+      Djuv,
+      DimmM,
+      DmatM,
+      DbreedM,
+      DimmF,
+      DmatF,
+      DbroodF,
+      DspentF,
+      DdistBrF,
+      BiomTotal,
+      Bjuv,
+      BimmM,
+      BmatM,
+      BbreedM,
+      BimmF,
+      BmatF,
+      BbroodF,
+      BspentF,
+      BdistBrF,
+      VolDenTotal,
+      VolDjuv,
+      VolDimmM,
+      VolDmatM,
+      VolDbreedM,
+      VolDimmF,
+      VolDmatF,
+      VolDbroodF,
+      VolDspentF,
+      VolDdisBrF,
+      `Eggs/BroodF`,
+      `Eggs/DistBrF`,
+      `Eggs/Total#Mysids`,
+      PropFemGravid
+    )
+  ) %>%
+    tidyr::pivot_longer(
+      cols = -c(Date, SiteID, Replicate),
+      names_to = "Parameter",
+      values_to = "Value"
+    )
+
+  readwritesqlite::rws_write(
+    x = mysid_data,
+    commit = commit,
+    strict = strict,
+    silent = silent,
+    x_name = "Mysid",
+    conn = conn,
+    replace = replace
   )
 }
 
@@ -155,7 +239,9 @@ nrp_upload_mysid <- function(data, db_path = getOption("nrp.db_path", file.choos
 #' @return Mysid sample table
 #' @export
 #'
-nrp_download_mysid_sample <- function(db_path = getOption("nrp.db_path", file.choose())) {
+nrp_download_mysid_sample <- function(
+  db_path = getOption("nrp.db_path", file.choose())
+) {
   conn <- db_path
 
   if (!inherits(conn, "SQLiteConnection")) {
@@ -177,9 +263,13 @@ nrp_download_mysid_sample <- function(db_path = getOption("nrp.db_path", file.ch
 #' @return CTD data table
 #' @export
 #'
-nrp_download_mysid <- function(start_date = NULL, end_date = NULL,
-                               sites = NULL, parameters = "all",
-                               db_path = getOption("nrp.db_path", file.choose())) {
+nrp_download_mysid <- function(
+  start_date = NULL,
+  end_date = NULL,
+  sites = NULL,
+  parameters = "all",
+  db_path = getOption("nrp.db_path", file.choose())
+) {
   chk::chk_null_or(sites, chk = chk::chk_character)
   chk::chk_character(parameters)
   chk::chk_null_or(start_date, chk = check_chr_date)
@@ -207,7 +297,10 @@ nrp_download_mysid <- function(start_date = NULL, end_date = NULL,
   }
 
   dates <- fill_date_query(
-    table = "Mysid", col = "Date", end = end_date, start = start_date,
+    table = "Mysid",
+    col = "Date",
+    end = end_date,
+    start = start_date,
     connection = conn
   )
   start_date <- dates["start_date"][[1]]
@@ -223,20 +316,38 @@ nrp_download_mysid <- function(start_date = NULL, end_date = NULL,
   sitesSql <- cc(sites, ellipsis = 1000)
   start_dateSql <- paste0("'", start_date, "'")
   end_dateSql <- paste0("'", end_date, "'")
-  colsSql <- cc(c("Date", "SiteID", "Replicate", "Parameter", "Value"),
-    ellipsis = 1000, brac = "`"
+  colsSql <- cc(
+    c("Date", "SiteID", "Replicate", "Parameter", "Value"),
+    ellipsis = 1000,
+    brac = "`"
   )
 
   query <- paste0(
-    "SELECT", colsSql, "FROM Mysid WHERE ((`Date` >= ", start_dateSql, ") AND (`Date` <= ",
-    end_dateSql, ") AND (`SiteID` IN (", sitesSql, ")) AND (`Parameter` IN (", paramsSql, ")))"
+    "SELECT",
+    colsSql,
+    "FROM Mysid WHERE ((`Date` >= ",
+    start_dateSql,
+    ") AND (`Date` <= ",
+    end_dateSql,
+    ") AND (`SiteID` IN (",
+    sitesSql,
+    ")) AND (`Parameter` IN (",
+    paramsSql,
+    ")))"
   )
 
-  result <- readwritesqlite::rws_query(query = query, conn = conn, meta = TRUE) %>%
+  result <- readwritesqlite::rws_query(
+    query = query,
+    conn = conn,
+    meta = TRUE
+  ) %>%
     dplyr::mutate(Date = dttr2::dtt_date(Date))
 
-  if (nrow(result) == 0) warning("no data available for query provided.")
+  if (nrow(result) == 0) {
+    warning("no data available for query provided.")
+  }
 
-  result %<>% tidyr::pivot_wider(names_from = "Parameter", values_from = "Value")
+  result %<>%
+    tidyr::pivot_wider(names_from = "Parameter", values_from = "Value")
   result
 }

--- a/R/phyto.R
+++ b/R/phyto.R
@@ -4,7 +4,10 @@
 #' @param db_path The SQLite connection object or path to the SQLite database
 #' @export
 #'
-nrp_add_phyto_species <- function(data, db_path = getOption("nrp.db_path", file.choose())) {
+nrp_add_phyto_species <- function(
+  data,
+  db_path = getOption("nrp.db_path", file.choose())
+) {
   conn <- db_path
   if (!inherits(conn, "SQLiteConnection")) {
     conn <- connect_if_valid_path(path = conn)
@@ -14,8 +17,12 @@ nrp_add_phyto_species <- function(data, db_path = getOption("nrp.db_path", file.
   check_new_phyto_species(data)
 
   readwritesqlite::rws_write(
-    x = data, commit = TRUE, strict = TRUE, silent = TRUE,
-    x_name = "PhytoplanktonSpecies", conn = conn
+    x = data,
+    commit = TRUE,
+    strict = TRUE,
+    silent = TRUE,
+    x_name = "PhytoplanktonSpecies",
+    conn = conn
   )
 }
 
@@ -24,7 +31,9 @@ nrp_add_phyto_species <- function(data, db_path = getOption("nrp.db_path", file.
 #' @return The phytoplankton species table
 #' @export
 #'
-nrp_download_phyto_species <- function(db_path = getOption("nrp.db_path", file.choose())) {
+nrp_download_phyto_species <- function(
+  db_path = getOption("nrp.db_path", file.choose())
+) {
   conn <- db_path
 
   if (!inherits(conn, "SQLiteConnection")) {
@@ -41,10 +50,13 @@ nrp_download_phyto_species <- function(db_path = getOption("nrp.db_path", file.c
 #' @return A tibble
 #' @export
 #'
-nrp_read_phyto_file <- function(path, db_path = getOption(
-                                  "nrp.db_path",
-                                  file.choose()
-                                )) {
+nrp_read_phyto_file <- function(
+  path,
+  db_path = getOption(
+    "nrp.db_path",
+    file.choose()
+  )
+) {
   check_file_exists(path)
 
   if (!inherits(db_path, "SQLiteConnection")) {
@@ -58,29 +70,49 @@ nrp_read_phyto_file <- function(path, db_path = getOption(
     err("Please ensure input data is a valid excel spreadsheet (.xlsx).")
   }
 
-  data %<>% filter(!all_na(data)) %>%
+  data %<>%
+    filter(!all_na(data)) %>%
     mutate(FileName = basename(path)) %>%
     clean_input_cols(lookup = nrp::phyto_input_cols) %>%
     transmute(
-      Samp_Date = Samp_Date, Site_Name,
+      Samp_Date = Samp_Date,
+      Site_Name,
       SiteLoc_LocName = str_replace(SiteLoc_LocName, "-", ""),
       Samp_Depth = str_replace(tolower(Samp_Depth), "m", ""),
-      Class_Name, Class_Alias,
+      Class_Name,
+      Class_Alias,
       Species_Name = str_replace_all(Species_Name, "\\.", ""),
-      Count_Number, `NCU/mL`, Species_Bvol,
-      `Biovolume (mm3/L)`, Biomass, Edibility, FileName
+      Count_Number,
+      `NCU/mL`,
+      Species_Bvol,
+      `Biovolume (mm3/L)`,
+      Biomass,
+      Edibility,
+      FileName
     )
 
   sites <- nrp_download_sites(db_path = db_path)
   if (!all(unique(data$SiteLoc_LocName) %in% sites$SiteID)) {
-    unknown <- unique(data$SiteLoc_LocName)[!unique(data$SiteLoc_LocName) %in% sites$SiteID]
-    warning("Sites in input data not present in 'Sites' table in database: ", paste_vec(unknown), ".")
+    unknown <- unique(data$SiteLoc_LocName)[
+      !unique(data$SiteLoc_LocName) %in% sites$SiteID
+    ]
+    warning(
+      "Sites in input data not present in 'Sites' table in database: ",
+      paste_vec(unknown),
+      "."
+    )
   }
 
   species <- nrp_download_phyto_species(db_path = db_path)
   if (!all(unique(data$Species_Name) %in% species$Taxa)) {
-    unknown <- unique(data$Species_Name)[!unique(data$Species_Name) %in% species$Taxa]
-    warning("Taxa in input data not present in 'PhytoplanktonSpecies' table in database: ", paste_vec(unknown), ".")
+    unknown <- unique(data$Species_Name)[
+      !unique(data$Species_Name) %in% species$Taxa
+    ]
+    warning(
+      "Taxa in input data not present in 'PhytoplanktonSpecies' table in database: ",
+      paste_vec(unknown),
+      "."
+    )
   }
 
   data
@@ -94,22 +126,33 @@ nrp_read_phyto_file <- function(path, db_path = getOption(
 #' @return A tibble.
 #' @export
 #'
-nrp_read_phyto <- function(path = ".", db_path = getOption("nrp.db_path", file.choose()),
-                           recursive = FALSE, regexp = "[.]xlsx$", fail = TRUE) {
+nrp_read_phyto <- function(
+  path = ".",
+  db_path = getOption("nrp.db_path", file.choose()),
+  recursive = FALSE,
+  regexp = "[.]xlsx$",
+  fail = TRUE
+) {
   check_dir_exists(path)
   chk::chk_chr(regexp)
   chk::chk_flag(recursive)
   chk::chk_flag(fail)
 
-  paths <- dir_ls(path,
-    type = "file", recurse = recursive, regexp = regexp,
+  paths <- dir_ls(
+    path,
+    type = "file",
+    recurse = recursive,
+    regexp = regexp,
     fail = fail
   )
   if (!length(paths)) {
     return(named_list())
   }
 
-  datas <- suppressWarnings(do.call("rbind", map(paths, ~ nrp_read_phyto_file(., db_path = db_path))))
+  datas <- suppressWarnings(do.call(
+    "rbind",
+    map(paths, ~ nrp_read_phyto_file(., db_path = db_path))
+  ))
   rownames(datas) <- NULL
 
   datas
@@ -122,9 +165,14 @@ nrp_read_phyto <- function(path = ".", db_path = getOption("nrp.db_path", file.c
 #' @inheritParams readwritesqlite::rws_write
 #' @export
 #'
-nrp_upload_phyto <- function(data, db_path = getOption("nrp.db_path", file.choose()),
-                             commit = TRUE, strict = TRUE, silent = TRUE,
-                             replace = FALSE) {
+nrp_upload_phyto <- function(
+  data,
+  db_path = getOption("nrp.db_path", file.choose()),
+  commit = TRUE,
+  strict = TRUE,
+  silent = TRUE,
+  replace = FALSE
+) {
   chk::chk_flag(replace)
   chk::chk_flag(commit)
   chk::chk_flag(strict)
@@ -137,9 +185,15 @@ nrp_upload_phyto <- function(data, db_path = getOption("nrp.db_path", file.choos
   }
 
   check_phyto_raw_data(data, exclusive = FALSE, order = FALSE)
-  chk::check_key(data, key = c("Samp_Date", "SiteLoc_LocName", "Samp_Depth", "Species_Name"))
+  chk::check_key(
+    data,
+    key = c("Samp_Date", "SiteLoc_LocName", "Samp_Depth", "Species_Name")
+  )
 
-  species <- readwritesqlite::rws_read_table("PhytoplanktonSpecies", conn = conn)
+  species <- readwritesqlite::rws_read_table(
+    "PhytoplanktonSpecies",
+    conn = conn
+  )
 
   data$Species_Name[1] <- "New"
 
@@ -152,17 +206,23 @@ nrp_upload_phyto <- function(data, db_path = getOption("nrp.db_path", file.choos
 
     spp_add <- ask_user(msg)
 
-    if (!spp_add) err("Upload aborted.")
+    if (!spp_add) {
+      err("Upload aborted.")
+    }
 
     new_species <- data %>%
       filter(!Species_Name %in% species$Taxa)
 
-    if (!"Genus" %in% names(new_species)) new_species$Genus <- NA_character_
+    if (!"Genus" %in% names(new_species)) {
+      new_species$Genus <- NA_character_
+    }
 
     new_species %<>%
       transmute(
-        Taxa = Species_Name, Genus,
-        ClassName = Class_Name, ClassAlias = Class_Alias
+        Taxa = Species_Name,
+        Genus,
+        ClassName = Class_Name,
+        ClassAlias = Class_Alias
       ) %>%
       distinct()
 
@@ -171,30 +231,44 @@ nrp_upload_phyto <- function(data, db_path = getOption("nrp.db_path", file.choos
 
   phyto_sample <- select(
     data,
-    Date = Samp_Date, SiteID = SiteLoc_LocName,
-    Depth = Samp_Depth, FileName
+    Date = Samp_Date,
+    SiteID = SiteLoc_LocName,
+    Depth = Samp_Depth,
+    FileName
   ) %>%
     distinct()
 
   readwritesqlite::rws_write(
-    x = phyto_sample, commit = commit,
-    strict = strict, silent = silent,
-    x_name = "PhytoplanktonSample", conn = conn, replace = replace
+    x = phyto_sample,
+    commit = commit,
+    strict = strict,
+    silent = silent,
+    x_name = "PhytoplanktonSample",
+    conn = conn,
+    replace = replace
   )
 
   phyto_data <- select(
     data,
-    Date = Samp_Date, SiteID = SiteLoc_LocName,
-    Depth = Samp_Depth, Taxa = Species_Name,
-    CellCount = Count_Number, Abundance = `NCU/mL`,
-    SpeciesBvol = Species_Bvol, Biovolume = `Biovolume (mm3/L)`,
+    Date = Samp_Date,
+    SiteID = SiteLoc_LocName,
+    Depth = Samp_Depth,
+    Taxa = Species_Name,
+    CellCount = Count_Number,
+    Abundance = `NCU/mL`,
+    SpeciesBvol = Species_Bvol,
+    Biovolume = `Biovolume (mm3/L)`,
     Biomass
   )
 
   readwritesqlite::rws_write(
-    x = phyto_data, commit = commit, strict = strict,
+    x = phyto_data,
+    commit = commit,
+    strict = strict,
     silent = silent,
-    x_name = "Phytoplankton", conn = conn, replace = replace
+    x_name = "Phytoplankton",
+    conn = conn,
+    replace = replace
   )
 }
 
@@ -210,9 +284,13 @@ nrp_upload_phyto <- function(data, db_path = getOption("nrp.db_path", file.choos
 #' @return Phytoplankton data table
 #' @export
 #'
-nrp_download_phyto <- function(start_date = NULL, end_date = NULL,
-                               sites = NULL, species = "all",
-                               db_path = getOption("nrp.db_path", file.choose())) {
+nrp_download_phyto <- function(
+  start_date = NULL,
+  end_date = NULL,
+  sites = NULL,
+  species = "all",
+  db_path = getOption("nrp.db_path", file.choose())
+) {
   chk::chk_null_or(sites, chk = chk::chk_character)
   chk::chk_character(species)
   chk::chk_null_or(start_date, chk = check_chr_date)
@@ -233,7 +311,10 @@ nrp_download_phyto <- function(start_date = NULL, end_date = NULL,
     err(paste("1 or more invalid site names"))
   }
 
-  species_db <- readwritesqlite::rws_read_table("PhytoplanktonSpecies", conn = conn)
+  species_db <- readwritesqlite::rws_read_table(
+    "PhytoplanktonSpecies",
+    conn = conn
+  )
 
   if (identical(species, "all")) {
     species <- species_db$Taxa
@@ -243,7 +324,10 @@ nrp_download_phyto <- function(start_date = NULL, end_date = NULL,
   }
 
   dates <- fill_date_query(
-    table = "Phytoplankton", col = "Date", end = end_date, start = start_date,
+    table = "Phytoplankton",
+    col = "Date",
+    end = end_date,
+    start = start_date,
     connection = conn
   )
 
@@ -262,13 +346,26 @@ nrp_download_phyto <- function(start_date = NULL, end_date = NULL,
   end_dateSql <- paste0("'", end_date, "'")
 
   query <- paste0(
-    "SELECT * FROM Phytoplankton WHERE ((`Date` >= ", start_dateSql, ") AND (`Date` <= ",
-    end_dateSql, ") AND (`SiteID` IN (", sitesSql, ")) AND (`Taxa` IN (", speciesSql, ")))"
+    "SELECT * FROM Phytoplankton WHERE ((`Date` >= ",
+    start_dateSql,
+    ") AND (`Date` <= ",
+    end_dateSql,
+    ") AND (`SiteID` IN (",
+    sitesSql,
+    ")) AND (`Taxa` IN (",
+    speciesSql,
+    ")))"
   )
 
-  result <- readwritesqlite::rws_query(query = query, conn = conn, meta = TRUE) %>%
+  result <- readwritesqlite::rws_query(
+    query = query,
+    conn = conn,
+    meta = TRUE
+  ) %>%
     dplyr::mutate(Date = dttr2::dtt_date(Date))
 
-  if (nrow(result) == 0) warning("no data available for query provided.")
+  if (nrow(result) == 0) {
+    warning("no data available for query provided.")
+  }
   result
 }

--- a/R/zoo.R
+++ b/R/zoo.R
@@ -6,10 +6,14 @@
 #' @return A tibble
 #' @export
 #'
-nrp_read_zooplankton_file <- function(path, db_path = getOption(
-                                        "nrp.db_path",
-                                        file.choose()
-                                      ), system = NULL) {
+nrp_read_zooplankton_file <- function(
+  path,
+  db_path = getOption(
+    "nrp.db_path",
+    file.choose()
+  ),
+  system = NULL
+) {
   check_file_exists(path)
   chk::chk_null_or(system, chk = chk::chk_chr)
   if (is.null(system)) {
@@ -18,11 +22,15 @@ nrp_read_zooplankton_file <- function(path, db_path = getOption(
     } else if (str_detect(tolower(basename(path)), "^kl")) {
       system <- "KL"
     } else {
-      err("System cannot be detected from file name. Please set system argument to 'arrow' or 'kootenay'.")
+      err(
+        "System cannot be detected from file name. Please set system argument to 'arrow' or 'kootenay'."
+      )
     }
   } else {
     system <- tolower(system)
-    if (!system %in% c("arrow", "kootenay")) err("'system' must be one of 'arrow', 'kootenay'.")
+    if (!system %in% c("arrow", "kootenay")) {
+      err("'system' must be one of 'arrow', 'kootenay'.")
+    }
     system <- ifelse(system == "arrow", "AR", "KL")
   }
 
@@ -48,7 +56,11 @@ nrp_read_zooplankton_file <- function(path, db_path = getOption(
 
   sites <- nrp_download_sites(db_path = db_path)
 
-  if (!all(unique(data$Station) %in% sites$SiteID)) warning("Sites present in input data that are not found in 'Sites' table in database.")
+  if (!all(unique(data$Station) %in% sites$SiteID)) {
+    warning(
+      "Sites present in input data that are not found in 'Sites' table in database."
+    )
+  }
 
   data
 }
@@ -62,24 +74,38 @@ nrp_read_zooplankton_file <- function(path, db_path = getOption(
 #' @return A tibble.
 #' @export
 #'
-nrp_read_zooplankton <- function(path = ".", db_path = getOption("nrp.db_path", file.choose()),
-                                 recursive = FALSE, system = NULL, regexp = "[.]xlsx$",
-                                 fail = TRUE) {
+nrp_read_zooplankton <- function(
+  path = ".",
+  db_path = getOption("nrp.db_path", file.choose()),
+  recursive = FALSE,
+  system = NULL,
+  regexp = "[.]xlsx$",
+  fail = TRUE
+) {
   check_dir_exists(path)
   chk::chk_null_or(system, chk = chk::chk_character)
   chk::chk_chr(regexp)
   chk::chk_flag(recursive)
   chk::chk_flag(fail)
 
-  paths <- dir_ls(path,
-    type = "file", recurse = recursive, regexp = regexp,
+  paths <- dir_ls(
+    path,
+    type = "file",
+    recurse = recursive,
+    regexp = regexp,
     fail = fail
   )
   if (!length(paths)) {
     return(named_list())
   }
 
-  datas <- suppressWarnings(do.call("rbind", map(paths, ~ nrp_read_zooplankton_file(., db_path = db_path, system = system))))
+  datas <- suppressWarnings(do.call(
+    "rbind",
+    map(
+      paths,
+      ~ nrp_read_zooplankton_file(., db_path = db_path, system = system)
+    )
+  ))
   rownames(datas) <- NULL
 
   datas
@@ -92,9 +118,14 @@ nrp_read_zooplankton <- function(path = ".", db_path = getOption("nrp.db_path", 
 #' @inheritParams readwritesqlite::rws_write
 #' @export
 #'
-nrp_upload_zooplankton <- function(data, db_path = getOption("nrp.db_path", file.choose()),
-                                   commit = TRUE, strict = TRUE, silent = TRUE,
-                                   replace = FALSE) {
+nrp_upload_zooplankton <- function(
+  data,
+  db_path = getOption("nrp.db_path", file.choose()),
+  commit = TRUE,
+  strict = TRUE,
+  silent = TRUE,
+  replace = FALSE
+) {
   chk::chk_flag(replace)
   chk::chk_flag(commit)
   chk::chk_flag(strict)
@@ -108,63 +139,204 @@ nrp_upload_zooplankton <- function(data, db_path = getOption("nrp.db_path", file
 
   check_zoo_raw_data(data, exclusive = TRUE, order = TRUE)
 
-  zoo_sample <- select(data, c(Date,
-    SiteID = Station, Replicate,
-    FileName, MonthCat, EndRev = ENDREV,
-    StartRev = STARTREV, SplMade = SPLmade,
-    SplCount = SPLcount, FundingSource, FieldCollection,
-    Analyst
-  ))
-
-  readwritesqlite::rws_write(
-    x = zoo_sample, commit = commit,
-    strict = strict, silent = silent,
-    x_name = "ZooplanktonSample", conn = conn, replace = replace
+  zoo_sample <- select(
+    data,
+    c(
+      Date,
+      SiteID = Station,
+      Replicate,
+      FileName,
+      MonthCat,
+      EndRev = ENDREV,
+      StartRev = STARTREV,
+      SplMade = SPLmade,
+      SplCount = SPLcount,
+      FundingSource,
+      FieldCollection,
+      Analyst
+    )
   )
 
-  zoo_data <- select(data, c(Date,
-    SiteID = Station, Replicate, FileName,
-    DenTotal, DCopep, DClad, `DClad other than Daph`,
-    DDash, DDkenai, DEpi, DCycl, DNaup,
-    DDaph, DDiaph, DBosm, DScap, DLepto,
-    DCerio, DChyd, DOtherCopep, DOtherClad,
-    DDashM, DDashF, DDash5, DDash4, DDash3,
-    DDash2, DDash1, DDashC, DDkenaiM, DDkenaiF,
-    DDkenaiC, DEpiM, DEpiF, DEpiC, DCyclM,
-    DCyclF, DCycl5, DCycl4, DCycl3, DCycl2,
-    DCycl1, DCyclC, BiomTotal, BCopep, BClad,
-    `BClad other than Daph`, BDash, BDkenai, BEpi,
-    BCycl, BNaup, BDaph, BDiaph, BBosm,
-    BScap, BLepto, BCerio, BChyd, BOtherCopep,
-    BOtherClad, BDashM, BDashF, BDash5, BDash4,
-    BDash3, BDash2, BDash1, BDashC, BDkenaiM,
-    BDkenaiF, BDkenaiC, BEpiM, BEpiF, BEpiC,
-    BCyclM, BCyclF, BCycl5, BCycl4, BCycl3,
-    BCycl2, BCycl1, BCyclC, F1Dash, F1Dkenai,
-    F1Epi, F1Cycl, F1Daph, F1Diaph, F1Bosm,
-    F1Scap, F1Lepto, F1Cerio, F1Chyd, F2Dash,
-    F2Dkenai, F2Epi, F2Cycl, F2Daph, F2Diaph,
-    F2Bosm, F2Scap, F2Lepto, F2Cerio, F2Chyd,
-    F3Dash, F3Dkenai, F3Epi, F3Cycl, F3Daph,
-    F3Diaph, F3Bosm, F3Scap, F3Lepto, F3Cerio,
-    F3Chyd, F4Dash, F4Dkenai, F4Epi, F4Cycl,
-    F4Daph, F4Diaph, F4Bosm, F4Scap, F4Lepto,
-    F4Cerio, F4Chyd, F5Dash, F5Dkenai, F5Epi,
-    F5Cycl, F5Daph, F5Diaph, F5Bosm, F5Scap,
-    F5Lepto, F5Cerio, F5Chyd, F6Dash, F6Dkenai,
-    F6Epi, F6Cycl, F6Daph, F6Diaph, F6Bosm,
-    F6Scap, F6Lepto, F6Cerio, F6Chyd
-  )) %>%
+  readwritesqlite::rws_write(
+    x = zoo_sample,
+    commit = commit,
+    strict = strict,
+    silent = silent,
+    x_name = "ZooplanktonSample",
+    conn = conn,
+    replace = replace
+  )
+
+  zoo_data <- select(
+    data,
+    c(
+      Date,
+      SiteID = Station,
+      Replicate,
+      FileName,
+      DenTotal,
+      DCopep,
+      DClad,
+      `DClad other than Daph`,
+      DDash,
+      DDkenai,
+      DEpi,
+      DCycl,
+      DNaup,
+      DDaph,
+      DDiaph,
+      DBosm,
+      DScap,
+      DLepto,
+      DCerio,
+      DChyd,
+      DOtherCopep,
+      DOtherClad,
+      DDashM,
+      DDashF,
+      DDash5,
+      DDash4,
+      DDash3,
+      DDash2,
+      DDash1,
+      DDashC,
+      DDkenaiM,
+      DDkenaiF,
+      DDkenaiC,
+      DEpiM,
+      DEpiF,
+      DEpiC,
+      DCyclM,
+      DCyclF,
+      DCycl5,
+      DCycl4,
+      DCycl3,
+      DCycl2,
+      DCycl1,
+      DCyclC,
+      BiomTotal,
+      BCopep,
+      BClad,
+      `BClad other than Daph`,
+      BDash,
+      BDkenai,
+      BEpi,
+      BCycl,
+      BNaup,
+      BDaph,
+      BDiaph,
+      BBosm,
+      BScap,
+      BLepto,
+      BCerio,
+      BChyd,
+      BOtherCopep,
+      BOtherClad,
+      BDashM,
+      BDashF,
+      BDash5,
+      BDash4,
+      BDash3,
+      BDash2,
+      BDash1,
+      BDashC,
+      BDkenaiM,
+      BDkenaiF,
+      BDkenaiC,
+      BEpiM,
+      BEpiF,
+      BEpiC,
+      BCyclM,
+      BCyclF,
+      BCycl5,
+      BCycl4,
+      BCycl3,
+      BCycl2,
+      BCycl1,
+      BCyclC,
+      F1Dash,
+      F1Dkenai,
+      F1Epi,
+      F1Cycl,
+      F1Daph,
+      F1Diaph,
+      F1Bosm,
+      F1Scap,
+      F1Lepto,
+      F1Cerio,
+      F1Chyd,
+      F2Dash,
+      F2Dkenai,
+      F2Epi,
+      F2Cycl,
+      F2Daph,
+      F2Diaph,
+      F2Bosm,
+      F2Scap,
+      F2Lepto,
+      F2Cerio,
+      F2Chyd,
+      F3Dash,
+      F3Dkenai,
+      F3Epi,
+      F3Cycl,
+      F3Daph,
+      F3Diaph,
+      F3Bosm,
+      F3Scap,
+      F3Lepto,
+      F3Cerio,
+      F3Chyd,
+      F4Dash,
+      F4Dkenai,
+      F4Epi,
+      F4Cycl,
+      F4Daph,
+      F4Diaph,
+      F4Bosm,
+      F4Scap,
+      F4Lepto,
+      F4Cerio,
+      F4Chyd,
+      F5Dash,
+      F5Dkenai,
+      F5Epi,
+      F5Cycl,
+      F5Daph,
+      F5Diaph,
+      F5Bosm,
+      F5Scap,
+      F5Lepto,
+      F5Cerio,
+      F5Chyd,
+      F6Dash,
+      F6Dkenai,
+      F6Epi,
+      F6Cycl,
+      F6Daph,
+      F6Diaph,
+      F6Bosm,
+      F6Scap,
+      F6Lepto,
+      F6Cerio,
+      F6Chyd
+    )
+  ) %>%
     tidyr::pivot_longer(
       cols = -c(Date, SiteID, Replicate, FileName),
-      names_to = "Parameter", values_to = "Value"
+      names_to = "Parameter",
+      values_to = "Value"
     ) %>%
     mutate(RawCount = NA_integer_)
 
   readwritesqlite::rws_write(
-    x = zoo_data, commit = commit, strict = strict,
+    x = zoo_data,
+    commit = commit,
+    strict = strict,
     silent = silent,
-    x_name = "Zooplankton", conn = conn, replace = replace
+    x_name = "Zooplankton",
+    conn = conn,
+    replace = replace
   )
 }
 
@@ -173,7 +345,9 @@ nrp_upload_zooplankton <- function(data, db_path = getOption("nrp.db_path", file
 #' @return Zooplankton sample table
 #' @export
 #'
-nrp_download_zoo_sample <- function(db_path = getOption("nrp.db_path", file.choose())) {
+nrp_download_zoo_sample <- function(
+  db_path = getOption("nrp.db_path", file.choose())
+) {
   conn <- db_path
 
   if (!inherits(conn, "SQLiteConnection")) {
@@ -196,9 +370,14 @@ nrp_download_zoo_sample <- function(db_path = getOption("nrp.db_path", file.choo
 #' @return CTD data table
 #' @export
 #'
-nrp_download_zooplankton <- function(start_date = NULL, end_date = NULL,
-                                     sites = NULL, parameters = "all", counts = FALSE,
-                                     db_path = getOption("nrp.db_path", file.choose())) {
+nrp_download_zooplankton <- function(
+  start_date = NULL,
+  end_date = NULL,
+  sites = NULL,
+  parameters = "all",
+  counts = FALSE,
+  db_path = getOption("nrp.db_path", file.choose())
+) {
   chk::chk_null_or(sites, chk = chk::chk_character)
   chk::chk_character(parameters)
   chk::chk_flag(counts)
@@ -227,7 +406,10 @@ nrp_download_zooplankton <- function(start_date = NULL, end_date = NULL,
   }
 
   dates <- fill_date_query(
-    table = "Zooplankton", col = "Date", end = end_date, start = start_date,
+    table = "Zooplankton",
+    col = "Date",
+    end = end_date,
+    start = start_date,
     connection = conn
   )
   start_date <- dates["start_date"][[1]]
@@ -245,23 +427,42 @@ nrp_download_zooplankton <- function(start_date = NULL, end_date = NULL,
   end_dateSql <- paste0("'", end_date, "'")
 
   cols <- c("Date", "SiteID", "Replicate", "FileName", "Parameter", "Value")
-  if (counts) cols[cols == "Value"] <- "RawCount"
+  if (counts) {
+    cols[cols == "Value"] <- "RawCount"
+  }
   colsSql <- cc(cols, ellipsis = 1000, brac = "`")
 
   query <- paste0(
-    "SELECT", colsSql, "FROM Zooplankton WHERE ((`Date` >= ", start_dateSql, ") AND (`Date` <= ",
-    end_dateSql, ") AND (`SiteID` IN (", sitesSql, ")) AND (`Parameter` IN (", paramsSql, ")))"
+    "SELECT",
+    colsSql,
+    "FROM Zooplankton WHERE ((`Date` >= ",
+    start_dateSql,
+    ") AND (`Date` <= ",
+    end_dateSql,
+    ") AND (`SiteID` IN (",
+    sitesSql,
+    ")) AND (`Parameter` IN (",
+    paramsSql,
+    ")))"
   )
 
-  result <- readwritesqlite::rws_query(query = query, conn = conn, meta = TRUE) %>%
+  result <- readwritesqlite::rws_query(
+    query = query,
+    conn = conn,
+    meta = TRUE
+  ) %>%
     dplyr::mutate(Date = dttr2::dtt_date(Date))
 
-  if (nrow(result) == 0) warning("no data available for query provided.")
+  if (nrow(result) == 0) {
+    warning("no data available for query provided.")
+  }
 
   if (counts) {
-    result %<>% tidyr::pivot_wider(names_from = "Parameter", values_from = "RawCount")
+    result %<>%
+      tidyr::pivot_wider(names_from = "Parameter", values_from = "RawCount")
   } else {
-    result %<>% tidyr::pivot_wider(names_from = "Parameter", values_from = "Value")
+    result %<>%
+      tidyr::pivot_wider(names_from = "Parameter", values_from = "Value")
   }
 
   result

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,7 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+default-exclude = true

--- a/data-raw/data-raw.R
+++ b/data-raw/data-raw.R
@@ -20,7 +20,14 @@ ctdSites <- read_csv("data-raw/ctdSites.csv") %>%
   ps_coords_to_sfc(crs = 26911) %>%
   st_transform(4326) %>%
   mutate(MaxDepth = set_units(MaxDepth, "m")) %>%
-  select(SiteID, EmsSiteNumber = SiteNumber, SiteName, EmsSiteName, BasinArm, MaxDepth)
+  select(
+    SiteID,
+    EmsSiteNumber = SiteNumber,
+    SiteName,
+    EmsSiteName,
+    BasinArm,
+    MaxDepth
+  )
 
 emsSites %<>%
   ps_coords_to_sfc(crs = 26911) %>%
@@ -30,30 +37,42 @@ ems_param_lookup <- read_excel("data-raw/Chem_parameter_lookup.xlsx")
 
 ems_param_lookup %<>%
   mutate(
-    PARAMETER = ifelse(PARAMETER %in% c("Phosphorus Total") &
-      ANALYTICAL_METHOD == "Total Metals in Water by ICPMS (Ultra)",
-    "Phosphorus Total metals", PARAMETER
+    PARAMETER = ifelse(
+      PARAMETER %in%
+        c("Phosphorus Total") &
+        ANALYTICAL_METHOD == "Total Metals in Water by ICPMS (Ultra)",
+      "Phosphorus Total metals",
+      PARAMETER
     ),
-    PARAMETER = ifelse(PARAMETER %in% c("Phosphorus Total Dissolved") &
-      ANALYTICAL_METHOD %in% c("ICP"), "Phosphorus Total Dissolved metals", PARAMETER),
-    Comment = ifelse(Comment == "metals; note that this parameter name is the same as the standard analysis - needs re-naming",
-      "metals", Comment
+    PARAMETER = ifelse(
+      PARAMETER %in%
+        c("Phosphorus Total Dissolved") &
+        ANALYTICAL_METHOD %in% c("ICP"),
+      "Phosphorus Total Dissolved metals",
+      PARAMETER
+    ),
+    Comment = ifelse(
+      Comment ==
+        "metals; note that this parameter name is the same as the standard analysis - needs re-naming",
+      "metals",
+      Comment
     )
   )
 
 basinArm <- as_tibble(ctdSites) %>%
   select(SiteID, BasinArm)
 
-basinArm$Lake[grepl("AR", basinArm$SiteID) | grepl("HL", basinArm$SiteID)] <- "Arrow"
+basinArm$Lake[
+  grepl("AR", basinArm$SiteID) | grepl("HL", basinArm$SiteID)
+] <- "Arrow"
 basinArm$Lake[grepl("KL", basinArm$SiteID)] <- "Kootenay"
 
-basinArm %<>% select(Lake, BasinArm) %>%
-  filter(!is.na(Lake)) %>%
-  unique()
+basinArm %<>% select(Lake, BasinArm) %>% filter(!is.na(Lake)) %>% unique()
 
 lakes <- st_read("data-raw/lakes.gpkg")
 lakes$Area <- st_area(lakes)
-lakes %<>% as_tibble() %>%
+lakes %<>%
+  as_tibble() %>%
   select(Lake, Area, geometry = geom) %>%
   ps_activate_sfc() %>%
   st_transform(4326)
@@ -248,31 +267,154 @@ zoo_input_cols <- c(
 )
 
 zoo_params <- c(
-  "SexFecCode", "CopStageCode",
-  "DenTotal", "DCopep", "DClad", "DClad other than Daph", "DDash",
-  "DDkenai", "DEpi", "DCycl", "DNaup", "DDaph", "DDiaph", "DBosm",
-  "DScap", "DLepto", "DCerio", "DChyd", "DOtherCopep", "DOtherClad",
-  "DDashM", "DDashF", "DDash5", "DDash4", "DDash3", "DDash2", "DDash1",
-  "DDashC", "DDkenaiM", "DDkenaiF", "DDkenaiC", "DEpiM", "DEpiF",
-  "DEpiC", "DCyclM", "DCyclF", "DCycl5", "DCycl4", "DCycl3", "DCycl2",
-  "DCycl1", "DCyclC", "BiomTotal", "BCopep", "BClad", "BClad other than Daph",
-  "BDash", "BDkenai", "BEpi", "BCycl", "BNaup", "BDaph", "BDiaph",
-  "BBosm", "BScap", "BLepto", "BCerio", "BChyd", "BOtherCopep",
-  "BOtherClad", "BDashM", "BDashF", "BDash5", "BDash4", "BDash3",
-  "BDash2", "BDash1", "BDashC", "BDkenaiM", "BDkenaiF", "BDkenaiC",
-  "BEpiM", "BEpiF", "BEpiC", "BCyclM", "BCyclF", "BCycl5", "BCycl4",
-  "BCycl3", "BCycl2", "BCycl1", "BCyclC", "F1Dash", "F1Dkenai",
-  "F1Epi", "F1Cycl", "F1Daph", "F1Diaph", "F1Bosm", "F1Scap", "F1Lepto",
-  "F1Cerio", "F1Chyd", "F2Dash", "F2Dkenai", "F2Epi", "F2Cycl",
-  "F2Daph", "F2Diaph", "F2Bosm", "F2Scap", "F2Lepto", "F2Cerio",
-  "F2Chyd", "F3Dash", "F3Dkenai", "F3Epi", "F3Cycl", "F3Daph",
-  "F3Diaph", "F3Bosm", "F3Scap", "F3Lepto", "F3Cerio", "F3Chyd",
-  "F4Dash", "F4Dkenai", "F4Epi", "F4Cycl", "F4Daph", "F4Diaph",
-  "F4Bosm", "F4Scap", "F4Lepto", "F4Cerio", "F4Chyd", "F5Dash",
-  "F5Dkenai", "F5Epi", "F5Cycl", "F5Daph", "F5Diaph", "F5Bosm",
-  "F5Scap", "F5Lepto", "F5Cerio", "F5Chyd", "F6Dash", "F6Dkenai",
-  "F6Epi", "F6Cycl", "F6Daph", "F6Diaph", "F6Bosm", "F6Scap", "F6Lepto",
-  "F6Cerio", "F6Chyd"
+  "SexFecCode",
+  "CopStageCode",
+  "DenTotal",
+  "DCopep",
+  "DClad",
+  "DClad other than Daph",
+  "DDash",
+  "DDkenai",
+  "DEpi",
+  "DCycl",
+  "DNaup",
+  "DDaph",
+  "DDiaph",
+  "DBosm",
+  "DScap",
+  "DLepto",
+  "DCerio",
+  "DChyd",
+  "DOtherCopep",
+  "DOtherClad",
+  "DDashM",
+  "DDashF",
+  "DDash5",
+  "DDash4",
+  "DDash3",
+  "DDash2",
+  "DDash1",
+  "DDashC",
+  "DDkenaiM",
+  "DDkenaiF",
+  "DDkenaiC",
+  "DEpiM",
+  "DEpiF",
+  "DEpiC",
+  "DCyclM",
+  "DCyclF",
+  "DCycl5",
+  "DCycl4",
+  "DCycl3",
+  "DCycl2",
+  "DCycl1",
+  "DCyclC",
+  "BiomTotal",
+  "BCopep",
+  "BClad",
+  "BClad other than Daph",
+  "BDash",
+  "BDkenai",
+  "BEpi",
+  "BCycl",
+  "BNaup",
+  "BDaph",
+  "BDiaph",
+  "BBosm",
+  "BScap",
+  "BLepto",
+  "BCerio",
+  "BChyd",
+  "BOtherCopep",
+  "BOtherClad",
+  "BDashM",
+  "BDashF",
+  "BDash5",
+  "BDash4",
+  "BDash3",
+  "BDash2",
+  "BDash1",
+  "BDashC",
+  "BDkenaiM",
+  "BDkenaiF",
+  "BDkenaiC",
+  "BEpiM",
+  "BEpiF",
+  "BEpiC",
+  "BCyclM",
+  "BCyclF",
+  "BCycl5",
+  "BCycl4",
+  "BCycl3",
+  "BCycl2",
+  "BCycl1",
+  "BCyclC",
+  "F1Dash",
+  "F1Dkenai",
+  "F1Epi",
+  "F1Cycl",
+  "F1Daph",
+  "F1Diaph",
+  "F1Bosm",
+  "F1Scap",
+  "F1Lepto",
+  "F1Cerio",
+  "F1Chyd",
+  "F2Dash",
+  "F2Dkenai",
+  "F2Epi",
+  "F2Cycl",
+  "F2Daph",
+  "F2Diaph",
+  "F2Bosm",
+  "F2Scap",
+  "F2Lepto",
+  "F2Cerio",
+  "F2Chyd",
+  "F3Dash",
+  "F3Dkenai",
+  "F3Epi",
+  "F3Cycl",
+  "F3Daph",
+  "F3Diaph",
+  "F3Bosm",
+  "F3Scap",
+  "F3Lepto",
+  "F3Cerio",
+  "F3Chyd",
+  "F4Dash",
+  "F4Dkenai",
+  "F4Epi",
+  "F4Cycl",
+  "F4Daph",
+  "F4Diaph",
+  "F4Bosm",
+  "F4Scap",
+  "F4Lepto",
+  "F4Cerio",
+  "F4Chyd",
+  "F5Dash",
+  "F5Dkenai",
+  "F5Epi",
+  "F5Cycl",
+  "F5Daph",
+  "F5Diaph",
+  "F5Bosm",
+  "F5Scap",
+  "F5Lepto",
+  "F5Cerio",
+  "F5Chyd",
+  "F6Dash",
+  "F6Dkenai",
+  "F6Epi",
+  "F6Cycl",
+  "F6Daph",
+  "F6Diaph",
+  "F6Bosm",
+  "F6Scap",
+  "F6Lepto",
+  "F6Cerio",
+  "F6Chyd"
 )
 
 
@@ -330,12 +472,40 @@ mysid_input_cols <- c(
 )
 
 mysid_params <- c(
-  "DenTotal", "Djuv", "DimmM", "DmatM", "DbreedM", "DimmF", "DmatF",
-  "DbroodF", "DspentF", "DdistBrF", "BiomTotal", "Bjuv", "BimmM",
-  "BmatM", "BbreedM", "BimmF", "BmatF", "BbroodF", "BspentF", "BdistBrF",
-  "VolDenTotal", "VolDjuv", "VolDimmM", "VolDmatM", "VolDbreedM",
-  "VolDimmF", "VolDmatF", "VolDbroodF", "VolDspentF", "VolDdisBrF",
-  "Eggs/BroodF", "Eggs/DistBrF", "Eggs/Total#Mysids", "PropFemGravid"
+  "DenTotal",
+  "Djuv",
+  "DimmM",
+  "DmatM",
+  "DbreedM",
+  "DimmF",
+  "DmatF",
+  "DbroodF",
+  "DspentF",
+  "DdistBrF",
+  "BiomTotal",
+  "Bjuv",
+  "BimmM",
+  "BmatM",
+  "BbreedM",
+  "BimmF",
+  "BmatF",
+  "BbroodF",
+  "BspentF",
+  "BdistBrF",
+  "VolDenTotal",
+  "VolDjuv",
+  "VolDimmM",
+  "VolDmatM",
+  "VolDbreedM",
+  "VolDimmF",
+  "VolDmatF",
+  "VolDbroodF",
+  "VolDspentF",
+  "VolDdisBrF",
+  "Eggs/BroodF",
+  "Eggs/DistBrF",
+  "Eggs/Total#Mysids",
+  "PropFemGravid"
 )
 
 phyto_input_cols <- c(

--- a/tests/testthat/test-check.R
+++ b/tests/testthat/test-check.R
@@ -1,12 +1,13 @@
 test_that("check_file_exists works", {
-  path <- system.file("extdata", "ctd/2018/KL1_27Aug2018008downcast.cnv",
-    package = "nrp", mustWork = TRUE
+  path <- system.file(
+    "extdata",
+    "ctd/2018/KL1_27Aug2018008downcast.cnv",
+    package = "nrp",
+    mustWork = TRUE
   )
   expect_identical(check_file_exists(path), path)
 
-  path <- system.file("extdata", "ctd",
-    package = "nrp", mustWork = TRUE
-  )
+  path <- system.file("extdata", "ctd", package = "nrp", mustWork = TRUE)
   expect_error(check_file_exists(path), "path '.*/extdata/ctd' must be a file")
 
   path <- paste0(path, "/missing", collapse = "")
@@ -17,17 +18,18 @@ test_that("check_file_exists works", {
 })
 
 test_that("check_dir_exists works", {
-  path <- system.file("extdata", "ctd/2018/KL1_27Aug2018008downcast.cnv",
-    package = "nrp", mustWork = TRUE
+  path <- system.file(
+    "extdata",
+    "ctd/2018/KL1_27Aug2018008downcast.cnv",
+    package = "nrp",
+    mustWork = TRUE
   )
   expect_error(
     check_dir_exists(path),
     "path '.*/extdata/ctd/2018/KL1_27Aug2018008downcast.cnv' must be a directory"
   )
 
-  path <- system.file("extdata", "ctd",
-    package = "nrp", mustWork = TRUE
-  )
+  path <- system.file("extdata", "ctd", package = "nrp", mustWork = TRUE)
   expect_identical(check_dir_exists(path), path)
 
   path <- paste0(path, "/missing", collapse = "")
@@ -42,10 +44,17 @@ test_that("check_chr_date works", {
   expect_error(check_chr_date(x), "`x` must be character.")
 
   x <- c("a", "a")
-  expect_error(check_chr_date(x), "`x` must be a scalar (length 1).", fixed = TRUE)
+  expect_error(
+    check_chr_date(x),
+    "`x` must be a scalar (length 1).",
+    fixed = TRUE
+  )
 
   x <- "a"
-  expect_error(check_chr_date(x), "Invalid date for `x`. Please use format: yyyy-mm-dd.")
+  expect_error(
+    check_chr_date(x),
+    "Invalid date for `x`. Please use format: yyyy-mm-dd."
+  )
 })
 
 test_that("check_chr_datetime works", {
@@ -53,11 +62,21 @@ test_that("check_chr_datetime works", {
   expect_error(check_chr_datetime(x), "`x` must be character.")
 
   x <- c("a", "a")
-  expect_error(check_chr_datetime(x), "`x` must be a scalar (length 1).", fixed = TRUE)
+  expect_error(
+    check_chr_datetime(x),
+    "`x` must be a scalar (length 1).",
+    fixed = TRUE
+  )
 
   x <- "a"
-  expect_error(check_chr_datetime(x), "Invalid date-time for `x`. Please use format: yyyy-mm-dd hh:mm:ss with 24 hour time.")
+  expect_error(
+    check_chr_datetime(x),
+    "Invalid date-time for `x`. Please use format: yyyy-mm-dd hh:mm:ss with 24 hour time."
+  )
 
   x <- "1/2/3"
-  expect_error(check_chr_datetime(x), "Invalid date-time for `x`. Please use format: yyyy-mm-dd hh:mm:ss with 24 hour time.")
+  expect_error(
+    check_chr_datetime(x),
+    "Invalid date-time for `x`. Please use format: yyyy-mm-dd hh:mm:ss with 24 hour time."
+  )
 })

--- a/tests/testthat/test-create-db.R
+++ b/tests/testthat/test-create-db.R
@@ -5,9 +5,20 @@ test_that("nrp-create-db works", {
   readwritesqlite::rws_list_tables(conn)
 
   tables <- c(
-    "BasinArm", "CTD", "Lake", "metalsEMS", "Mysid", "MysidSample",
-    "Phytoplankton", "PhytoplanktonSample", "PhytoplanktonSpecies",
-    "Sites", "standardEMS", "VisitCTD", "Zooplankton", "ZooplanktonSample"
+    "BasinArm",
+    "CTD",
+    "Lake",
+    "metalsEMS",
+    "Mysid",
+    "MysidSample",
+    "Phytoplankton",
+    "PhytoplanktonSample",
+    "PhytoplanktonSpecies",
+    "Sites",
+    "standardEMS",
+    "VisitCTD",
+    "Zooplankton",
+    "ZooplanktonSample"
   )
 
   expect_identical(sort(readwritesqlite::rws_list_tables(conn)), sort(tables))

--- a/tests/testthat/test-ctd.R
+++ b/tests/testthat/test-ctd.R
@@ -2,14 +2,24 @@ test_that("nrp_read_ctd_file works", {
   conn <- nrp_create_db(path = ":memory:", ask = FALSE)
   teardown(DBI::dbDisconnect(conn))
 
-  path <- system.file("extdata", "ctd/2018/KL1_27Aug2018008downcast.cnv", package = "nrp", mustWork = TRUE)
+  path <- system.file(
+    "extdata",
+    "ctd/2018/KL1_27Aug2018008downcast.cnv",
+    package = "nrp",
+    mustWork = TRUE
+  )
   data <- nrp_read_ctd_file(path, db_path = conn)
 
   check_ctd_data(data, exclusive = TRUE, order = TRUE)
   expect_is(data, "tbl_df")
   expect_identical(nrow(data), 1413L)
 
-  path <- system.file("extdata", "bad ctd/2018/KL_badly_named_file.cnv", package = "nrp", mustWork = TRUE)
+  path <- system.file(
+    "extdata",
+    "bad ctd/2018/KL_badly_named_file.cnv",
+    package = "nrp",
+    mustWork = TRUE
+  )
 
   expect_error(
     data <- nrp_read_ctd_file(path, db_path = conn),
@@ -20,7 +30,12 @@ test_that("nrp_read_ctd_file works", {
 test_that("nrp_read_ctd_file w/ read.table alternative works", {
   conn <- nrp_create_db(path = ":memory:", ask = FALSE)
   teardown(DBI::dbDisconnect(conn))
-  path <- system.file("extdata", "bad ctd/2018/AR6_Apr_26_2011.cnv", package = "nrp", mustWork = TRUE)
+  path <- system.file(
+    "extdata",
+    "bad ctd/2018/AR6_Apr_26_2011.cnv",
+    package = "nrp",
+    mustWork = TRUE
+  )
 
   data <- nrp_read_ctd_file(path, db_path = conn)
 
@@ -33,7 +48,12 @@ test_that("nrp_read_ctd_file w/ read.table alternative works", {
 test_that("nrp_read_ctd_file delineates up and down casts", {
   conn <- nrp_create_db(path = ":memory:", ask = FALSE)
   teardown(DBI::dbDisconnect(conn))
-  path <- system.file("extdata", "ctd/2025/KL6_02Sep2025001downcast&upcast.cnv", package = "nrp", mustWork = TRUE)
+  path <- system.file(
+    "extdata",
+    "ctd/2025/KL6_02Sep2025001downcast&upcast.cnv",
+    package = "nrp",
+    mustWork = TRUE
+  )
 
   data <- nrp_read_ctd_file(path, db_path = conn)
 
@@ -101,8 +121,13 @@ test_that("nrp_download_ctd_basin_arm works", {
 
 test_that("nrp_add_sites works", {
   new_data <- tibble(
-    SiteID = "NewID", EmsSiteNumber = "NewNumber", SiteName = "New Site Name",
-    EmsSiteName = "name ems", BasinArm = "Upper", MaxDepth = 100, Easting = -75.32016,
+    SiteID = "NewID",
+    EmsSiteNumber = "NewNumber",
+    SiteName = "New Site Name",
+    EmsSiteName = "name ems",
+    BasinArm = "Upper",
+    MaxDepth = 100,
+    Easting = -75.32016,
     Northing = 2.932139
   )
 
@@ -121,8 +146,11 @@ test_that("nrp_add_sites works", {
 
 test_that("nrp_upload_ctd works", {
   conn <- nrp_create_db(path = ":memory:", ask = FALSE)
-  path <- system.file("extdata", "ctd/2018/KL1_27Aug2018008downcast.cnv",
-    package = "nrp", mustWork = TRUE
+  path <- system.file(
+    "extdata",
+    "ctd/2018/KL1_27Aug2018008downcast.cnv",
+    package = "nrp",
+    mustWork = TRUE
   )
   data <- nrp_read_ctd_file(path = path, db_path = conn)
 
@@ -153,8 +181,11 @@ test_that("nrp_upload_ctd works", {
 
 test_that("nrp_upload_ctd(replace = TRUE) works", {
   conn <- nrp_create_db(path = ":memory:", ask = FALSE)
-  path <- system.file("extdata", "ctd/2018/KL1_27Aug2018008downcast.cnv",
-    package = "nrp", mustWork = TRUE
+  path <- system.file(
+    "extdata",
+    "ctd/2018/KL1_27Aug2018008downcast.cnv",
+    package = "nrp",
+    mustWork = TRUE
   )
   data <- nrp_read_ctd_file(path = path, db_path = conn)
   data %<>% mutate(Flag = 1)
@@ -185,7 +216,8 @@ test_that("nrp_download_ctd works", {
   db_data <- nrp_download_ctd(
     start_date = "2018-08-26",
     end_date = "2018-08-28",
-    sites = NULL, db_path = conn
+    sites = NULL,
+    db_path = conn
   )
 
   expect_is(data, "tbl_df")

--- a/tests/testthat/test-mysid.R
+++ b/tests/testthat/test-mysid.R
@@ -2,12 +2,18 @@ test_that("nrp_read_mysid_file works", {
   conn <- nrp_create_db(path = ":memory:", ask = FALSE)
   teardown(DBI::dbDisconnect(conn))
 
-  path <- system.file("extdata", "mysid/KLFmys20.xlsx",
-    package = "nrp", mustWork = TRUE
+  path <- system.file(
+    "extdata",
+    "mysid/KLFmys20.xlsx",
+    package = "nrp",
+    mustWork = TRUE
   )
 
-  wrong_path <- system.file("extdata", "ar-empty.rtf",
-    package = "nrp", mustWork = TRUE
+  wrong_path <- system.file(
+    "extdata",
+    "ar-empty.rtf",
+    package = "nrp",
+    mustWork = TRUE
   )
 
   data <- nrp_read_mysid_file(path = path, db_path = conn) %>%
@@ -32,9 +38,7 @@ test_that("nrp_read_mysid works", {
   conn <- nrp_create_db(path = ":memory:", ask = FALSE)
   teardown(DBI::dbDisconnect(conn))
 
-  path <- system.file("extdata", "mysid",
-    package = "nrp", mustWork = TRUE
-  )
+  path <- system.file("extdata", "mysid", package = "nrp", mustWork = TRUE)
   data <- nrp_read_mysid(path, db_path = conn)
 
   expect_is(data, "tbl_df")
@@ -46,9 +50,7 @@ test_that("nrp_read_mysid works", {
     "path 'not-a-path' must exist"
   )
 
-  path <- system.file("extdata",
-    package = "nrp", mustWork = TRUE
-  )
+  path <- system.file("extdata", package = "nrp", mustWork = TRUE)
   data <- nrp_read_mysid(path, db_path = conn)
   expect_identical(data, list(x = 1)[-1])
 })
@@ -57,8 +59,11 @@ test_that("nrp_upload_mysid and nrp_download_mysid_visit works", {
   conn <- nrp_create_db(path = ":memory:", ask = FALSE)
   teardown(DBI::dbDisconnect(conn))
 
-  path <- system.file("extdata", "mysid/KLFmys20.xlsx",
-    package = "nrp", mustWork = TRUE
+  path <- system.file(
+    "extdata",
+    "mysid/KLFmys20.xlsx",
+    package = "nrp",
+    mustWork = TRUE
   )
 
   data <- nrp_read_mysid_file(path = path, db_path = conn) %>%
@@ -87,7 +92,8 @@ test_that("nrp_upload_mysid and nrp_download_mysid_visit works", {
 
   db_data <- nrp_download_mysid(
     start_date = "2020-04-01",
-    end_date = "2020-04-25", db_path = conn
+    end_date = "2020-04-25",
+    db_path = conn
   )
 
   expect_identical(length(db_data), 37L)
@@ -96,7 +102,8 @@ test_that("nrp_upload_mysid and nrp_download_mysid_visit works", {
   expect_error(
     nrp_download_mysid(
       start_date = "2020-04-01",
-      end_date = "2020-04-25", db_path = conn,
+      end_date = "2020-04-25",
+      db_path = conn,
       sites = "wrong"
     ),
     "1 or more invalid site names"
@@ -105,7 +112,8 @@ test_that("nrp_upload_mysid and nrp_download_mysid_visit works", {
   expect_error(
     nrp_download_mysid(
       start_date = "2020-04-01",
-      end_date = "2020-04-25", db_path = conn,
+      end_date = "2020-04-25",
+      db_path = conn,
       parameters = "wrong"
     ),
     "1 or more invalid parameter names"

--- a/tests/testthat/test-phyto.R
+++ b/tests/testthat/test-phyto.R
@@ -23,11 +23,19 @@ test_that("nrp_read_plytoplankton_file works", {
   conn <- nrp_create_db(path = ":memory:", ask = FALSE)
   teardown(DBI::dbDisconnect(conn))
 
-  path <- system.file("extdata", "phyto/phyto1.xlsx",
-    package = "nrp", mustWork = TRUE
+  path <- system.file(
+    "extdata",
+    "phyto/phyto1.xlsx",
+    package = "nrp",
+    mustWork = TRUE
   )
 
-  wrong_path <- system.file("extdata", "ar-empty.rtf", package = "nrp", mustWork = TRUE)
+  wrong_path <- system.file(
+    "extdata",
+    "ar-empty.rtf",
+    package = "nrp",
+    mustWork = TRUE
+  )
 
   data <- nrp_read_phyto_file(path = path, db_path = conn) %>%
     suppressWarnings()
@@ -46,8 +54,11 @@ test_that("nrp_read_plytoplankton_file works", {
     "Please ensure input data is a valid excel spreadsheet \\(.xlsx\\)."
   )
 
-  path2 <- system.file("extdata", "phyto/bad/phyto2.xlsx",
-    package = "nrp", mustWork = TRUE
+  path2 <- system.file(
+    "extdata",
+    "phyto/bad/phyto2.xlsx",
+    package = "nrp",
+    mustWork = TRUE
   )
 
   expect_warning(
@@ -55,8 +66,11 @@ test_that("nrp_read_plytoplankton_file works", {
     "Sites in input data not present in 'Sites' table in database: 'AR12'."
   )
 
-  path3 <- system.file("extdata", "phyto/bad/phyto3.xlsx",
-    package = "nrp", mustWork = TRUE
+  path3 <- system.file(
+    "extdata",
+    "phyto/bad/phyto3.xlsx",
+    package = "nrp",
+    mustWork = TRUE
   )
 
   expect_warning(
@@ -70,8 +84,10 @@ test_that("nrp_read_phyto works", {
   teardown(DBI::dbDisconnect(conn))
 
   path <- system.file(
-    "extdata", "phyto",
-    package = "nrp", mustWork = TRUE
+    "extdata",
+    "phyto",
+    package = "nrp",
+    mustWork = TRUE
   )
 
   data <- nrp_read_phyto(path, db_path = conn)
@@ -81,8 +97,11 @@ test_that("nrp_read_phyto works", {
   expect_identical(nrow(data), 5L)
 
   path <- system.file(
-    "extdata", "phyto", "multiple",
-    package = "nrp", mustWork = TRUE
+    "extdata",
+    "phyto",
+    "multiple",
+    package = "nrp",
+    mustWork = TRUE
   )
 
   data <- nrp_read_phyto(path, db_path = conn, recursive = TRUE)
@@ -92,7 +111,8 @@ test_that("nrp_read_phyto works", {
   expect_identical(nrow(data), 15L)
 
   expect_error(
-    nrp_read_phyto("not-a-path", db_path = conn), "path 'not-a-path' must exist"
+    nrp_read_phyto("not-a-path", db_path = conn),
+    "path 'not-a-path' must exist"
   )
 
   path <- system.file("extdata", package = "nrp", mustWork = TRUE)
@@ -104,8 +124,11 @@ test_that("nrp_upload_phyto works", {
   conn <- nrp_create_db(path = ":memory:", ask = FALSE)
   teardown(DBI::dbDisconnect(conn))
 
-  path <- system.file("extdata", "phyto/phyto1.xlsx",
-    package = "nrp", mustWork = TRUE
+  path <- system.file(
+    "extdata",
+    "phyto/phyto1.xlsx",
+    package = "nrp",
+    mustWork = TRUE
   )
 
   data <- nrp_read_phyto_file(path = path, db_path = conn) %>%
@@ -160,8 +183,11 @@ test_that("nrp_download_phyto works", {
   conn <- nrp_create_db(path = ":memory:", ask = FALSE)
   teardown(DBI::dbDisconnect(conn))
 
-  path <- system.file("extdata", "phyto/phyto1.xlsx",
-    package = "nrp", mustWork = TRUE
+  path <- system.file(
+    "extdata",
+    "phyto/phyto1.xlsx",
+    package = "nrp",
+    mustWork = TRUE
   )
 
   data <- nrp_read_phyto_file(path = path, db_path = conn) %>%
@@ -177,7 +203,11 @@ test_that("nrp_download_phyto works", {
   expect_identical(length(db_data), 9L)
   expect_identical(nrow(db_data), 5L)
 
-  db_data <- nrp_download_phyto(start_date = "2022-01-01", end_date = "2022-01-03", db_path = conn)
+  db_data <- nrp_download_phyto(
+    start_date = "2022-01-01",
+    end_date = "2022-01-03",
+    db_path = conn
+  )
   expect_identical(nrow(db_data), 2L)
   expect_identical(db_data$Date, dttr2::dtt_date(c("2022-01-02", "2022-01-03")))
 
@@ -185,7 +215,10 @@ test_that("nrp_download_phyto works", {
   expect_identical(nrow(db_data), 1L)
   expect_identical(db_data$SiteID, "KL1")
 
-  db_data <- nrp_download_phyto(species = "Gymnodinium sp (medium)", db_path = conn)
+  db_data <- nrp_download_phyto(
+    species = "Gymnodinium sp (medium)",
+    db_path = conn
+  )
   expect_identical(nrow(db_data), 1L)
   expect_identical(db_data$Taxa, "Gymnodinium sp (medium)")
 
@@ -205,7 +238,11 @@ test_that("nrp_download_phyto works", {
   )
 
   expect_error(
-    nrp_download_phyto(start_date = "2022-01-03", end_date = "2022-01-02", db_path = conn),
+    nrp_download_phyto(
+      start_date = "2022-01-03",
+      end_date = "2022-01-02",
+      db_path = conn
+    ),
     "start date is later than end date"
   )
 })

--- a/tests/testthat/test-zoo.R
+++ b/tests/testthat/test-zoo.R
@@ -2,11 +2,19 @@ test_that("nrp_read_zooplankton_file works", {
   conn <- nrp_create_db(path = ":memory:", ask = FALSE)
   teardown(DBI::dbDisconnect(conn))
 
-  path <- system.file("extdata", "zooplankton/Arzp20.xlsx",
-    package = "nrp", mustWork = TRUE
+  path <- system.file(
+    "extdata",
+    "zooplankton/Arzp20.xlsx",
+    package = "nrp",
+    mustWork = TRUE
   )
 
-  wrong_path <- system.file("extdata", "ar-empty.rtf", package = "nrp", mustWork = TRUE)
+  wrong_path <- system.file(
+    "extdata",
+    "ar-empty.rtf",
+    package = "nrp",
+    mustWork = TRUE
+  )
 
   data <- nrp_read_zooplankton_file(path = path, db_path = conn) %>%
     suppressWarnings()
@@ -30,8 +38,11 @@ test_that("nrp_read_zooplankton works", {
   conn <- nrp_create_db(path = ":memory:", ask = FALSE)
   teardown(DBI::dbDisconnect(conn))
 
-  path <- system.file("extdata", "zooplankton",
-    package = "nrp", mustWork = TRUE
+  path <- system.file(
+    "extdata",
+    "zooplankton",
+    package = "nrp",
+    mustWork = TRUE
   )
   data <- nrp_read_zooplankton(path, db_path = conn)
 
@@ -44,9 +55,7 @@ test_that("nrp_read_zooplankton works", {
     "path 'not-a-path' must exist"
   )
 
-  path <- system.file("extdata",
-    package = "nrp", mustWork = TRUE
-  )
+  path <- system.file("extdata", package = "nrp", mustWork = TRUE)
   data <- nrp_read_zooplankton(path, db_path = conn)
   expect_identical(data, list(x = 1)[-1])
 })
@@ -55,8 +64,11 @@ test_that("nrp_upload_zooplankton and nrp_download_zoo_sample works", {
   conn <- nrp_create_db(path = ":memory:", ask = FALSE)
   teardown(DBI::dbDisconnect(conn))
 
-  path <- system.file("extdata", "zooplankton/Arzp20.xlsx",
-    package = "nrp", mustWork = TRUE
+  path <- system.file(
+    "extdata",
+    "zooplankton/Arzp20.xlsx",
+    package = "nrp",
+    mustWork = TRUE
   )
 
   data <- nrp_read_zooplankton_file(path = path, db_path = conn) %>%
@@ -84,7 +96,8 @@ test_that("nrp_upload_zooplankton and nrp_download_zoo_sample works", {
   )
   db_data <- nrp_download_zooplankton(
     start_date = "2020-04-01",
-    end_date = "2020-04-25", db_path = conn
+    end_date = "2020-04-25",
+    db_path = conn
   )
 
   expect_identical(length(db_data), 150L)
@@ -104,7 +117,8 @@ test_that("nrp_upload_zooplankton and nrp_download_zoo_sample works", {
   expect_error(
     nrp_download_zooplankton(
       start_date = "2020-04-01",
-      end_date = "2020-04-25", db_path = conn,
+      end_date = "2020-04-25",
+      db_path = conn,
       sites = "wrong"
     ),
     "1 or more invalid site names"
@@ -113,7 +127,8 @@ test_that("nrp_upload_zooplankton and nrp_download_zoo_sample works", {
   expect_error(
     nrp_download_zooplankton(
       start_date = "2020-04-01",
-      end_date = "2020-04-25", db_path = conn,
+      end_date = "2020-04-25",
+      db_path = conn,
       parameters = "wrong"
     ),
     "1 or more invalid parameter names"


### PR DESCRIPTION
Adds air formatting following the org standard (as in `chk`):

- `air.toml` with the standard `[format]` settings
- `.vscode/` settings recommending and enabling format-on-save with Posit air
- `.Rbuildignore` entries for `air.toml` and `.vscode`
- All R source formatted with `air format .` (air 0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)